### PR TITLE
Adds simple in-game Responsiveness

### DIFF
--- a/src/main/java/br/com/sbk/sbking/gui/constants/FrameConstants.java
+++ b/src/main/java/br/com/sbk/sbking/gui/constants/FrameConstants.java
@@ -6,6 +6,7 @@ import java.awt.Point;
 
 import br.com.sbk.sbking.core.Direction;
 
+// (TODO) refactor this class to reduce instruction duplication. 
 public final class FrameConstants {
 	public static final java.awt.Color TABLE_COLOR = new java.awt.Color(0, 100, 0); // Tablecloth green
 	public static int TABLE_WIDTH = 1024;

--- a/src/main/java/br/com/sbk/sbking/gui/constants/FrameConstants.java
+++ b/src/main/java/br/com/sbk/sbking/gui/constants/FrameConstants.java
@@ -8,28 +8,28 @@ import br.com.sbk.sbking.core.Direction;
 
 public final class FrameConstants {
 	public static final java.awt.Color TABLE_COLOR = new java.awt.Color(0, 100, 0); // Tablecloth green
-	public static final int TABLE_WIDTH = 1024;
-	public static final int TABLE_HEIGHT = 768;
+	public static int TABLE_WIDTH = 1024;
+	public static int TABLE_HEIGHT = 768;
 
-	public static final int HALF_WIDTH = TABLE_WIDTH / 2;
-	public static final int HALF_HEIGHT = TABLE_HEIGHT / 2;
-	private static final int FIFTH_WIDTH = TABLE_WIDTH / 5;
-	private static final int FIFTH_HEIGHT = TABLE_HEIGHT / 5;
+	public static int HALF_WIDTH = TABLE_WIDTH / 2;
+	public static int HALF_HEIGHT = TABLE_HEIGHT / 2;
+	private static int FIFTH_WIDTH = TABLE_WIDTH / 5;
+	private static int FIFTH_HEIGHT = TABLE_HEIGHT / 5;
 
-	private static final int NORTH_X_CENTER = HALF_WIDTH;
-	private static final int NORTH_Y_CENTER = FIFTH_HEIGHT;
+	private static int NORTH_X_CENTER = HALF_WIDTH;
+	private static int NORTH_Y_CENTER = FIFTH_HEIGHT;
 
-	private static final int SOUTH_X_CENTER = HALF_WIDTH;
-	private static final int SOUTH_Y_CENTER = FIFTH_HEIGHT * 4;
+	private static int SOUTH_X_CENTER = HALF_WIDTH;
+	private static int SOUTH_Y_CENTER = FIFTH_HEIGHT * 4;
 
-	private static final int EAST_X_CENTER = FIFTH_WIDTH * 4;
-	private static final int EAST_Y_CENTER = HALF_HEIGHT;
+	private static int EAST_X_CENTER = FIFTH_WIDTH * 4;
+	private static int EAST_Y_CENTER = HALF_HEIGHT;
 
-	private static final int WEST_X_CENTER = FIFTH_WIDTH;
-	private static final int WEST_Y_CENTER = HALF_HEIGHT;
+	private static int WEST_X_CENTER = FIFTH_WIDTH;
+	private static int WEST_Y_CENTER = HALF_HEIGHT;
 
 	@SuppressWarnings("serial")
-	public static final Map<Direction, Point> pointOfDirection = new HashMap<Direction, Point>() {
+	public static Map<Direction, Point> pointOfDirection = new HashMap<Direction, Point>() {
 		{
 			put(Direction.NORTH, new Point(NORTH_X_CENTER, NORTH_Y_CENTER));
 			put(Direction.EAST, new Point(EAST_X_CENTER, EAST_Y_CENTER));
@@ -37,4 +37,35 @@ public final class FrameConstants {
 			put(Direction.WEST, new Point(WEST_X_CENTER, WEST_Y_CENTER));
 		}
 	};
+
+	public static void computeConstants(int newWidth, int newHeight) {
+		TABLE_WIDTH = newWidth;
+		TABLE_HEIGHT = newHeight;
+
+		HALF_WIDTH = TABLE_WIDTH / 2;
+		HALF_HEIGHT = TABLE_HEIGHT / 2;
+		FIFTH_WIDTH = TABLE_WIDTH / 5;
+		FIFTH_HEIGHT = TABLE_HEIGHT / 5;
+
+		NORTH_X_CENTER = HALF_WIDTH;
+		NORTH_Y_CENTER = FIFTH_HEIGHT;
+
+		SOUTH_X_CENTER = HALF_WIDTH;
+		SOUTH_Y_CENTER = FIFTH_HEIGHT * 4;
+
+		EAST_X_CENTER = FIFTH_WIDTH * 4;
+		EAST_Y_CENTER = HALF_HEIGHT;
+
+		WEST_X_CENTER = FIFTH_WIDTH;
+		WEST_Y_CENTER = HALF_HEIGHT;
+
+		pointOfDirection = new HashMap<Direction, Point>() {
+			{
+				put(Direction.NORTH, new Point(NORTH_X_CENTER, NORTH_Y_CENTER));
+				put(Direction.EAST, new Point(EAST_X_CENTER, EAST_Y_CENTER));
+				put(Direction.SOUTH, new Point(SOUTH_X_CENTER, SOUTH_Y_CENTER));
+				put(Direction.WEST, new Point(WEST_X_CENTER, WEST_Y_CENTER));
+			}
+		};
+	}
 }

--- a/src/main/java/br/com/sbk/sbking/gui/elements/HandElement.java
+++ b/src/main/java/br/com/sbk/sbking/gui/elements/HandElement.java
@@ -26,7 +26,7 @@ public class HandElement {
 	private DeckCardImageInformation deckCardImageInformation;
 
 	public HandElement(Hand hand, Container container, ActionListener actionListener, Point handCenter, Player player,
-			boolean isVisible, Direction direction) {
+		boolean isVisible, Direction direction) {
 		this.deckCardImageInformation = new DeckCardImageInformation();
 
 		int x_offset = ((hand.size() + 1) * BETWEEN_CARDS_WIDTH) / 2;
@@ -54,14 +54,14 @@ public class HandElement {
 		JButton sitOrLeaveButton = new SitOrLeaveButton(direction);
 		sitOrLeaveButton.addActionListener(actionListener);
 		if (player == null) {
-      sitOrLeaveButton.setText("Click to seat.");
+			sitOrLeaveButton.setText("Click to seat.");
 		} else{
-      sitOrLeaveButton.setText(player.getName());
+			sitOrLeaveButton.setText(player.getName());
 		}
 		
-		Point inicio = handTopLeftCorner;
+		Point startingPoint = handTopLeftCorner;
 		handTopLeftCorner.translate(0, deckCardImageInformation.getCardHeight() + 5);
-		sitOrLeaveButton.setLocation(inicio);
+		sitOrLeaveButton.setLocation(startingPoint);
 		container.add(sitOrLeaveButton);
 	}
 

--- a/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
@@ -158,5 +158,4 @@ public class NetworkClientScreen extends JFrame {
 		Matcher mtch = ptn.matcher(ipAddr);
 		return mtch.find();
 	}
-
 }

--- a/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
@@ -115,7 +115,6 @@ public class NetworkClientScreen extends JFrame {
 					paintDeal(currentDeal, sbKingClient.getDirection(), sbKingClient.getPlayCardActionListener());
 					logger.info("Finished painting Deal");
 				}
-
 			}
 			sleepFor(300);
 		}

--- a/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
@@ -5,8 +5,10 @@ import static br.com.sbk.sbking.gui.constants.FrameConstants.TABLE_HEIGHT;
 import static br.com.sbk.sbking.gui.constants.FrameConstants.TABLE_WIDTH;
 
 import java.awt.event.ActionListener;
-import java.util.concurrent.ExecutorService;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -18,6 +20,7 @@ import org.apache.logging.log4j.Logger;
 import br.com.sbk.sbking.core.Board;
 import br.com.sbk.sbking.core.Deal;
 import br.com.sbk.sbking.core.Direction;
+import br.com.sbk.sbking.gui.constants.FrameConstants;
 import br.com.sbk.sbking.gui.painters.ConnectToServerPainter;
 import br.com.sbk.sbking.gui.painters.DealPainter;
 import br.com.sbk.sbking.gui.painters.FinalScoreboardPainter;
@@ -43,6 +46,18 @@ public class NetworkClientScreen extends JFrame {
 		initializeJFrame();
 		initializeContentPane();
 		pool = Executors.newFixedThreadPool(4);
+		NetworkClientScreen screen = this;
+
+		this.addComponentListener(new ComponentAdapter() {
+			public void componentResized(ComponentEvent componentEvent) {
+				// Recompute frame constants. 
+				// TODO rename "constant" since they are no longer fixed.
+				FrameConstants.computeConstants(screen.getWidth(), screen.getHeight());
+				
+				// Reposition stuff in the board.
+				
+			}
+		});
 	}
 
 	private void initializeJFrame() {

--- a/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
@@ -97,7 +97,7 @@ public class NetworkClientScreen extends JFrame {
 				}
 
 			}
-				sleepFor(300);
+			sleepFor(300);
 		}
 	}
 

--- a/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
@@ -154,7 +154,6 @@ public class NetworkClientScreen extends JFrame {
 	}
 
 	private boolean isValidIP(String ipAddr) {
-
 		Pattern ptn = Pattern.compile("^(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})$");
 		Matcher mtch = ptn.matcher(ipAddr);
 		return mtch.find();

--- a/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
@@ -61,11 +61,11 @@ public class NetworkClientScreen extends JFrame {
 		this.addComponentListener(new ComponentAdapter() {
 			public void componentResized(ComponentEvent componentEvent) {
 				// Recompute frame constants. 
-				// TODO rename "constant" since they are no longer fixed.
 				FrameConstants.computeConstants(screen.getWidth(), screen.getHeight());
 				
-				// Appropriate paint calls will deal with repositioning GUI components on screen accordign to new precomputed constants.
+				// Connecting screen has no sbKingClient to store the GUI invalidation flag.
 				if (sbKingClient != null) {
+					// Invalidating the client's GUI flag provekes a Pane repaint on the main loop.
 					sbKingClient.setGUIHasChanged(true);
 				}
 			}

--- a/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
@@ -46,18 +46,6 @@ public class NetworkClientScreen extends JFrame {
 		initializeJFrame();
 		initializeContentPane();
 		pool = Executors.newFixedThreadPool(4);
-		NetworkClientScreen screen = this;
-
-		this.addComponentListener(new ComponentAdapter() {
-			public void componentResized(ComponentEvent componentEvent) {
-				// Recompute frame constants. 
-				// TODO rename "constant" since they are no longer fixed.
-				FrameConstants.computeConstants(screen.getWidth(), screen.getHeight());
-				
-				// Reposition stuff in the board.
-				
-			}
-		});
 	}
 
 	private void initializeJFrame() {
@@ -69,6 +57,19 @@ public class NetworkClientScreen extends JFrame {
 	private void initializeContentPane() {
 		getContentPane().setLayout(null);
 		getContentPane().setBackground(TABLE_COLOR);
+		NetworkClientScreen screen = this;
+		this.addComponentListener(new ComponentAdapter() {
+			public void componentResized(ComponentEvent componentEvent) {
+				// Recompute frame constants. 
+				// TODO rename "constant" since they are no longer fixed.
+				FrameConstants.computeConstants(screen.getWidth(), screen.getHeight());
+				
+				// Appropriate paint calls will deal with repositioning GUI components on screen accordign to new precomputed constants.
+				if (sbKingClient != null) {
+					sbKingClient.setGUIHasChanged(true);
+				}
+			}
+		});
 	}
 
 	public void run() {
@@ -88,9 +89,11 @@ public class NetworkClientScreen extends JFrame {
 
 		while (true) {
 			if(sbKingClient.isSpectator()){
-				if(sbKingClient.getBoardHasChanged() || sbKingClient.getDealHasChanged()){
-					logger.info("Deal has changed. Painting deal.");
-					logger.info("It is a spectator.");
+				if(sbKingClient.getBoardHasChanged() || sbKingClient.getDealHasChanged() || sbKingClient.getGUIHasChanged()){
+					if (!sbKingClient.getGUIHasChanged()) {
+						logger.info("Deal has changed. Painting deal.");
+						logger.info("It is a spectator.");
+					}
 					Deal currentDeal = sbKingClient.getDeal();
 					Board currentBoard = sbKingClient.getCurrentBoard();
 					if (currentDeal == null) {
@@ -101,9 +104,11 @@ public class NetworkClientScreen extends JFrame {
 				}
 			}
 			else{
-				if (sbKingClient.getDealHasChanged()) {
-					logger.info("Deal has changed. Painting deal.");
-					logger.info("It is a player.");
+				if (sbKingClient.getDealHasChanged() || sbKingClient.getGUIHasChanged()) {
+					if (sbKingClient.getDealHasChanged()) {
+						logger.info("Deal has changed. Painting deal.");
+						logger.info("It is a player.");
+					}
 					Deal currentDeal = sbKingClient.getDeal();
 
 					logger.info("Starting to paint Deal");
@@ -127,6 +132,10 @@ public class NetworkClientScreen extends JFrame {
 	private void paintPainter(Painter painter) {
 		this.getContentPane().removeAll();
 		painter.paint(this.getContentPane());
+
+		if (sbKingClient != null) {
+			sbKingClient.setGUIHasChanged(false);
+		}
 	}
 
 	private void paintConnectToServerScreen() {

--- a/src/main/java/br/com/sbk/sbking/networking/client/SBKingClient.java
+++ b/src/main/java/br/com/sbk/sbking/networking/client/SBKingClient.java
@@ -41,6 +41,8 @@ public class SBKingClient implements Runnable {
 	private boolean dealFinished;
 	private Boolean rulesetValid = null;
 
+	private boolean guiHasChanged = false;
+
 	private boolean gameFinished = false;
 
 	private KingGameScoreboard currentGameScoreboard = new KingGameScoreboard();
@@ -373,6 +375,14 @@ public class SBKingClient implements Runnable {
 
 	public boolean getDealHasChanged(){
 		return this.dealHasChanged;
+	}
+
+	public void setGUIHasChanged(boolean guiHasChanged){
+		this.guiHasChanged = guiHasChanged;
+	}
+
+	public boolean getGUIHasChanged(){
+		return this.guiHasChanged;
 	}
 
 	public boolean isDealFinished() {


### PR DESCRIPTION
This change proposes a simple in game responsiveness.

It adds a listener to a screen resize event on the NetworkClient screen. This invalidates a GUI flag, used to inkove appropriate paint methods in the game main loop, as well as recalculate all positioning constants on the FrameConstants class.

TODO: improve FrameConstants.java to reduce instruction duplication.
TODO: split connecting screen and in-game screen
TODO: Increase card sizes and card spacing in hand. This will be done in a future PR.