### PR TITLE
[fix] re-validates GUI state after resize

### DIFF
--- a/src/main/java/br/com/sbk/sbking/gui/frames/CagandoNetworkClientScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/frames/CagandoNetworkClientScreen.java
@@ -82,6 +82,9 @@ public class CagandoNetworkClientScreen extends NetworkClientScreen {
 	private void paintPainter(Painter painter) {
 		this.getContentPane().removeAll();
 		painter.paint(this.getContentPane());
+		if (sbKingClient != null) {
+			sbKingClient.setGUIHasChanged(false);
+		}
 	}
 
 	private void paintConnectToServerScreen() {

--- a/src/main/java/br/com/sbk/sbking/gui/frames/PositiveKingNetworkClientScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/frames/PositiveKingNetworkClientScreen.java
@@ -120,6 +120,9 @@ public class PositiveKingNetworkClientScreen extends NetworkClientScreen {
 	private void paintPainter(Painter painter) {
 		this.getContentPane().removeAll();
 		painter.paint(this.getContentPane());
+		if (sbKingClient != null) {
+			sbKingClient.setGUIHasChanged(false);
+		}
 	}
 
 	private void paintConnectToServerScreen() {

--- a/src/main/java/br/com/sbk/sbking/networking/client/SBKingClient.java
+++ b/src/main/java/br/com/sbk/sbking/networking/client/SBKingClient.java
@@ -377,8 +377,6 @@ public class SBKingClient implements Runnable {
 	}
 
 	public boolean getGUIHasChanged() {
-		boolean returnValue = this.guiHasChanged;
-		this.guiHasChanged = false;
 		return returnValue;
 	}
 


### PR DESCRIPTION
Rebase conflict fix for PR adding resize feature ([original PR](https://github.com/rulojuka/sbking/pull/4) vs [rebased PR](https://github.com/rulojuka/sbking/blob/5c343e171e4b612c8c23600dcd14df7a347ed806/src/main/java/br/com/sbk/sbking/gui/frames/PositiveKingNetworkClientScreen.java#L120-L122)) incorrectly removed GUI revalidation painter invokation.
This bug causes the screen to repaint at every frame.