### PR TITLE
[refact] frame constants and app state

### DIFF
--- a/src/main/java/br/com/sbk/sbking/gui/constants/FrameConstants.java
+++ b/src/main/java/br/com/sbk/sbking/gui/constants/FrameConstants.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.awt.Point;
 
 import br.com.sbk.sbking.core.Direction;
+import br.com.sbk.sbking.gui.main.ClientApplicationState;
 
 public final class FrameConstants {
 	public static final java.awt.Color TABLE_COLOR = new java.awt.Color(0, 100, 0); // Tablecloth green
@@ -15,7 +16,7 @@ public final class FrameConstants {
 	public static int HALF_HEIGHT;
 
 	@SuppressWarnings("serial")
-	public static Map<Direction, Point> pointOfDirection;
+	public static Map<Direction, Point> pointOfDirection = new HashMap<Direction, Point>();
 
 	public static void initFrameConstants() {
 		computeConstants(1024, 768);		
@@ -43,13 +44,14 @@ public final class FrameConstants {
 		int WEST_X_CENTER = FIFTH_WIDTH;
 		int WEST_Y_CENTER = HALF_HEIGHT;
 
-		pointOfDirection = new HashMap<Direction, Point>() {
-			{
-				put(Direction.NORTH, new Point(NORTH_X_CENTER, NORTH_Y_CENTER));
-				put(Direction.EAST, new Point(EAST_X_CENTER, EAST_Y_CENTER));
-				put(Direction.SOUTH, new Point(SOUTH_X_CENTER, SOUTH_Y_CENTER));
-				put(Direction.WEST, new Point(WEST_X_CENTER, WEST_Y_CENTER));
-			}
-		};
+		// TODO: cached references to the points stored in pointOfDirection may
+		// be invalid. We must prevent caching of those references.
+		pointOfDirection.clear();
+		pointOfDirection.put(Direction.NORTH, new Point(NORTH_X_CENTER, NORTH_Y_CENTER));
+		pointOfDirection.put(Direction.EAST, new Point(EAST_X_CENTER, EAST_Y_CENTER));
+		pointOfDirection.put(Direction.SOUTH, new Point(SOUTH_X_CENTER, SOUTH_Y_CENTER));
+		pointOfDirection.put(Direction.WEST, new Point(WEST_X_CENTER, WEST_Y_CENTER));
+
+		ClientApplicationState.setGUIHasChanged(true);
 	}
 }

--- a/src/main/java/br/com/sbk/sbking/gui/constants/FrameConstants.java
+++ b/src/main/java/br/com/sbk/sbking/gui/constants/FrameConstants.java
@@ -6,38 +6,20 @@ import java.awt.Point;
 
 import br.com.sbk.sbking.core.Direction;
 
-// (TODO) refactor this class to reduce instruction duplication. 
 public final class FrameConstants {
 	public static final java.awt.Color TABLE_COLOR = new java.awt.Color(0, 100, 0); // Tablecloth green
-	public static int TABLE_WIDTH = 1024;
-	public static int TABLE_HEIGHT = 768;
+	public static int TABLE_WIDTH;
+	public static int TABLE_HEIGHT;
 
-	public static int HALF_WIDTH = TABLE_WIDTH / 2;
-	public static int HALF_HEIGHT = TABLE_HEIGHT / 2;
-	private static int FIFTH_WIDTH = TABLE_WIDTH / 5;
-	private static int FIFTH_HEIGHT = TABLE_HEIGHT / 5;
-
-	private static int NORTH_X_CENTER = HALF_WIDTH;
-	private static int NORTH_Y_CENTER = FIFTH_HEIGHT;
-
-	private static int SOUTH_X_CENTER = HALF_WIDTH;
-	private static int SOUTH_Y_CENTER = FIFTH_HEIGHT * 4;
-
-	private static int EAST_X_CENTER = FIFTH_WIDTH * 4;
-	private static int EAST_Y_CENTER = HALF_HEIGHT;
-
-	private static int WEST_X_CENTER = FIFTH_WIDTH;
-	private static int WEST_Y_CENTER = HALF_HEIGHT;
+	public static int HALF_WIDTH;
+	public static int HALF_HEIGHT;
 
 	@SuppressWarnings("serial")
-	public static Map<Direction, Point> pointOfDirection = new HashMap<Direction, Point>() {
-		{
-			put(Direction.NORTH, new Point(NORTH_X_CENTER, NORTH_Y_CENTER));
-			put(Direction.EAST, new Point(EAST_X_CENTER, EAST_Y_CENTER));
-			put(Direction.SOUTH, new Point(SOUTH_X_CENTER, SOUTH_Y_CENTER));
-			put(Direction.WEST, new Point(WEST_X_CENTER, WEST_Y_CENTER));
-		}
-	};
+	public static Map<Direction, Point> pointOfDirection;
+
+	public static void initFrameConstants() {
+		computeConstants(1024, 768);		
+	}
 
 	public static void computeConstants(int newWidth, int newHeight) {
 		TABLE_WIDTH = newWidth;
@@ -45,20 +27,21 @@ public final class FrameConstants {
 
 		HALF_WIDTH = TABLE_WIDTH / 2;
 		HALF_HEIGHT = TABLE_HEIGHT / 2;
-		FIFTH_WIDTH = TABLE_WIDTH / 5;
-		FIFTH_HEIGHT = TABLE_HEIGHT / 5;
+		
+		int FIFTH_WIDTH = TABLE_WIDTH / 5;
+		int FIFTH_HEIGHT = TABLE_HEIGHT / 5;
 
-		NORTH_X_CENTER = HALF_WIDTH;
-		NORTH_Y_CENTER = FIFTH_HEIGHT;
+		int NORTH_X_CENTER = HALF_WIDTH;
+		int NORTH_Y_CENTER = FIFTH_HEIGHT;
 
-		SOUTH_X_CENTER = HALF_WIDTH;
-		SOUTH_Y_CENTER = FIFTH_HEIGHT * 4;
+		int SOUTH_X_CENTER = HALF_WIDTH;
+		int SOUTH_Y_CENTER = FIFTH_HEIGHT * 4;
 
-		EAST_X_CENTER = FIFTH_WIDTH * 4;
-		EAST_Y_CENTER = HALF_HEIGHT;
+		int EAST_X_CENTER = FIFTH_WIDTH * 4;
+		int EAST_Y_CENTER = HALF_HEIGHT;
 
-		WEST_X_CENTER = FIFTH_WIDTH;
-		WEST_Y_CENTER = HALF_HEIGHT;
+		int WEST_X_CENTER = FIFTH_WIDTH;
+		int WEST_Y_CENTER = HALF_HEIGHT;
 
 		pointOfDirection = new HashMap<Direction, Point>() {
 			{

--- a/src/main/java/br/com/sbk/sbking/gui/frames/CagandoNetworkClientScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/frames/CagandoNetworkClientScreen.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.Logger;
 import br.com.sbk.sbking.core.Board;
 import br.com.sbk.sbking.core.Deal;
 import br.com.sbk.sbking.core.Direction;
+import br.com.sbk.sbking.gui.main.ClientApplicationState;
 import br.com.sbk.sbking.gui.painters.ConnectToServerPainter;
 import br.com.sbk.sbking.gui.painters.DealPainter;
 import br.com.sbk.sbking.gui.painters.Painter;
@@ -40,8 +41,8 @@ public class CagandoNetworkClientScreen extends NetworkClientScreen {
 
 		while (true) {
 			if (sbKingClient.isSpectator()) {
-				if (sbKingClient.getBoardHasChanged() || sbKingClient.getDealHasChanged() || sbKingClient.getGUIHasChanged()) {
-					if (!sbKingClient.getGUIHasChanged()) {
+				if (sbKingClient.getBoardHasChanged() || sbKingClient.getDealHasChanged() || ClientApplicationState.getGUIHasChanged()) {
+					if (!ClientApplicationState.getGUIHasChanged()) {
 						logger.info("Deal has changed. Painting deal.");
 						logger.info("It is a spectator.");
 					}
@@ -54,8 +55,8 @@ public class CagandoNetworkClientScreen extends NetworkClientScreen {
 					}
 				}
 			} else {
-				if (sbKingClient.getDealHasChanged() || sbKingClient.getGUIHasChanged()) {
-					if (!sbKingClient.getGUIHasChanged()) {
+				if (sbKingClient.getDealHasChanged() || ClientApplicationState.getGUIHasChanged()) {
+					if (!ClientApplicationState.getGUIHasChanged()) {
 						logger.info("Deal has changed. Painting deal.");
 						logger.info("It is a player.");
 					}

--- a/src/main/java/br/com/sbk/sbking/gui/frames/KingNetworkClientScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/frames/KingNetworkClientScreen.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.Logger;
 import br.com.sbk.sbking.core.Board;
 import br.com.sbk.sbking.core.Deal;
 import br.com.sbk.sbking.core.Direction;
+import br.com.sbk.sbking.gui.main.ClientApplicationState;
 import br.com.sbk.sbking.gui.painters.ConnectToServerPainter;
 import br.com.sbk.sbking.gui.painters.DealPainter;
 import br.com.sbk.sbking.gui.painters.Painter;
@@ -42,8 +43,8 @@ public class KingNetworkClientScreen extends NetworkClientScreen {
 		while (true) {
 			sleepFor(300);
 			if (sbKingClient.isSpectator()) {
-				if (sbKingClient.getBoardHasChanged() || sbKingClient.getDealHasChanged() || sbKingClient.getGUIHasChanged()) {
-					if (!sbKingClient.getGUIHasChanged()) {
+				if (sbKingClient.getBoardHasChanged() || sbKingClient.getDealHasChanged() || ClientApplicationState.getGUIHasChanged()) {
+					if (!ClientApplicationState.getGUIHasChanged()) {
 						logger.info("Deal has changed. Painting deal.");
 						logger.info("It is a spectator.");
 					}
@@ -57,8 +58,8 @@ public class KingNetworkClientScreen extends NetworkClientScreen {
 				}
 			} else {
 				sleepFor(1000);
-				if (sbKingClient.getDealHasChanged() || sbKingClient.getGUIHasChanged()) {
-					if (!sbKingClient.getGUIHasChanged()) {
+				if (sbKingClient.getDealHasChanged() || ClientApplicationState.getGUIHasChanged()) {
+					if (!ClientApplicationState.getGUIHasChanged()) {
 						logger.info("Deal has changed. Painting deal.");
 						logger.info("It is a player.");
 					}

--- a/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/frames/NetworkClientScreen.java
@@ -21,8 +21,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import br.com.sbk.sbking.gui.constants.FrameConstants;
+import br.com.sbk.sbking.gui.main.ClientApplicationState;
 import br.com.sbk.sbking.gui.painters.Painter;
 import br.com.sbk.sbking.networking.client.SBKingClient;
+
 
 @SuppressWarnings("serial")
 public abstract class NetworkClientScreen extends JFrame {
@@ -55,14 +57,7 @@ public abstract class NetworkClientScreen extends JFrame {
 		NetworkClientScreen screen = this;
 		this.addComponentListener(new ComponentAdapter() {
 			public void componentResized(ComponentEvent componentEvent) {
-				// Recompute frame constants.
-				FrameConstants.computeConstants(screen.getWidth(), screen.getHeight());
-
-				// Connecting screen has no sbKingClient to store the GUI invalidation flag.
-				if (sbKingClient != null) {
-					// Invalidating the client's GUI flag provekes a Pane repaint on the main loop.
-					sbKingClient.setGUIHasChanged(true);
-				}
+				ClientApplicationState.resizeWindow(screen.getWidth(), screen.getHeight());
 			}
 		});
 	}
@@ -114,8 +109,6 @@ public abstract class NetworkClientScreen extends JFrame {
 	protected void paintPainter(Painter painter) {
 		this.getContentPane().removeAll();
 		painter.paint(this.getContentPane());
-		if (sbKingClient != null) {
-			sbKingClient.setGUIHasChanged(false);
-		}
+		ClientApplicationState.setGUIHasChanged(false);
 	}
 }

--- a/src/main/java/br/com/sbk/sbking/gui/frames/PositiveKingNetworkClientScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/frames/PositiveKingNetworkClientScreen.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.Logger;
 import br.com.sbk.sbking.core.Board;
 import br.com.sbk.sbking.core.Deal;
 import br.com.sbk.sbking.core.Direction;
+import br.com.sbk.sbking.gui.main.ClientApplicationState;
 import br.com.sbk.sbking.gui.painters.ConnectToServerPainter;
 import br.com.sbk.sbking.gui.painters.DealPainter;
 import br.com.sbk.sbking.gui.painters.FinalScoreboardPainter;
@@ -44,8 +45,8 @@ public class PositiveKingNetworkClientScreen extends NetworkClientScreen {
 		while (true) {
 			sleepFor(300);
 			if (sbKingClient.isSpectator()) {
-				if (sbKingClient.getBoardHasChanged() || sbKingClient.getDealHasChanged() || sbKingClient.getGUIHasChanged()) {
-					if (!sbKingClient.getGUIHasChanged()) {
+				if (sbKingClient.getBoardHasChanged() || sbKingClient.getDealHasChanged() || ClientApplicationState.getGUIHasChanged()) {
+					if (!ClientApplicationState.getGUIHasChanged()) {
 						logger.info("Deal has changed. Painting deal.");
 						logger.info("It is a spectator.");
 					}
@@ -59,8 +60,8 @@ public class PositiveKingNetworkClientScreen extends NetworkClientScreen {
 				}
 			} else {
 				sleepFor(1000);
-				if (sbKingClient.getDealHasChanged() || sbKingClient.getGUIHasChanged()) {
-					if (!sbKingClient.getGUIHasChanged()) {
+				if (sbKingClient.getDealHasChanged() || ClientApplicationState.getGUIHasChanged()) {
+					if (!ClientApplicationState.getGUIHasChanged()) {
 						logger.info("Deal has changed. Painting deal.");
 						logger.info("It is a player.");
 					}

--- a/src/main/java/br/com/sbk/sbking/gui/main/ClientApplicationState.java
+++ b/src/main/java/br/com/sbk/sbking/gui/main/ClientApplicationState.java
@@ -28,10 +28,7 @@ public class ClientApplicationState {
 	public static void resizeWindow(int width, int height) {
 		logger.info("Resizing Window");
 
-		// Recompute frame constants.
 		FrameConstants.computeConstants(width, height);
-
-		guiHasChanged = true;
 	}
 
 }

--- a/src/main/java/br/com/sbk/sbking/gui/main/ClientApplicationState.java
+++ b/src/main/java/br/com/sbk/sbking/gui/main/ClientApplicationState.java
@@ -1,0 +1,37 @@
+package br.com.sbk.sbking.gui.main;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import br.com.sbk.sbking.gui.constants.FrameConstants;
+
+public class ClientApplicationState {
+
+	final static Logger logger = LogManager.getLogger(ClientApplicationState.class);
+	private static boolean guiHasChanged = false;
+
+
+	public static void setGUIHasChanged(boolean changed) {
+		guiHasChanged = changed;
+	}
+
+	public static boolean getGUIHasChanged() {
+		return guiHasChanged;
+	}
+
+	public static void startAppState() {
+		logger.info("Initializing Frame Constants");
+		
+		FrameConstants.initFrameConstants();
+	}
+
+	public static void resizeWindow(int width, int height) {
+		logger.info("Resizing Window");
+
+		// Recompute frame constants.
+		FrameConstants.computeConstants(width, height);
+
+		guiHasChanged = true;
+	}
+
+}

--- a/src/main/java/br/com/sbk/sbking/gui/main/MainNetworkGame.java
+++ b/src/main/java/br/com/sbk/sbking/gui/main/MainNetworkGame.java
@@ -5,12 +5,14 @@ import org.apache.logging.log4j.Logger;
 
 import br.com.sbk.sbking.gui.frames.KingNetworkClientScreen;
 import br.com.sbk.sbking.gui.frames.NetworkClientScreen;
+import br.com.sbk.sbking.gui.main.ClientApplicationState;
 
 public class MainNetworkGame {
 
 	final static Logger logger = LogManager.getLogger(MainNetworkGame.class);
 
 	public static void main(String args[]) {
+		ClientApplicationState.startAppState();
 		NetworkClientScreen networkClientScreen = new KingNetworkClientScreen();
 		networkClientScreen.run();
 		logger.info("Exiting main thread.");

--- a/src/main/java/br/com/sbk/sbking/networking/client/SBKingClient.java
+++ b/src/main/java/br/com/sbk/sbking/networking/client/SBKingClient.java
@@ -40,8 +40,6 @@ public class SBKingClient implements Runnable {
 	private boolean dealFinished;
 	private Boolean rulesetValid = null;
 
-	private boolean guiHasChanged = false;
-
 	private boolean gameFinished = false;
 
 	private KingGameScoreboard currentGameScoreboard = new KingGameScoreboard();
@@ -357,14 +355,6 @@ public class SBKingClient implements Runnable {
 
 	public boolean getDealHasChanged() {
 		return this.dealHasChanged;
-	}
-
-	public void setGUIHasChanged(boolean guiHasChanged) {
-		this.guiHasChanged = guiHasChanged;
-	}
-
-	public boolean getGUIHasChanged() {
-		return this.guiHasChanged;
 	}
 
 	public boolean isDealFinished() {


### PR DESCRIPTION
Refactoring FrameConstants to avoid instrution duplication. Removed TODO.

Created a Client State static class that manages the entire application wide settings, regardless of client connectivity or game rule (unlike sbkingClient for instance).

This new class allows for app-wide changes (like frame constants) to be kept at a centralize, authoritative single source. It also provides an early app entry point to set configuration settings, (like TABLE_WIDTH and all other constants) ensuring they are set before being used.