### PR TITLE
[fix] severity of check MagicNumber increased on core files.

### DIFF
--- a/checkstyle/sbking_checkstyle.xml
+++ b/checkstyle/sbking_checkstyle.xml
@@ -54,9 +54,8 @@
 
   <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
   <module name="SuppressionFilter">
-    <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
-              default="checkstyle-suppressions.xml" />
-    <property name="optional" value="true"/>
+    <property name="file" value="checkstyle/suppressions.xml"/>
+    <property name="optional" value="false"/>
   </module>
 
   <!-- Checks whether files end with a new line.                        -->
@@ -154,9 +153,14 @@
     <module name="IllegalInstantiation"/>
     <module name="InnerAssignment"/>
 
-    <!-- TODO bump MagicNumber severity to error once existing violations are resolved -->
+    <!-- TODO bump MagicNumber severity on core to error once existing violations are resolved -->
     <module name="MagicNumber">
-      <property name="severity" value="warning"/>
+        <property name="id" value="core"/>
+        <property name="severity" value="warning"/>
+    </module>
+    <module name="MagicNumber">
+        <property name="id" value="non-core"/>
+        <property name="severity" value="info"/>
     </module>
 
     <module name="MissingSwitchDefault"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -5,6 +5,9 @@
 "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
+    <!-- Suppress checks annotated with id core for files in gui folder -->
     <suppress id="core" files="[/\\]src[/\\]main[/\\]java[/\\]br[/\\]com[/\\]sbk[/\\]sbking[/\\]gui[/\\].*" />
+
+    <!-- Suppress checks annotated with id non-core for files .*/core/.* folders -->
     <suppress id="non-core" files="[/\\]src[/\\]main[/\\].*[/\\]core[/\\].*" />
 </suppressions>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+"-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+"https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+    <suppress id="core" files="[/\\]src[/\\]main[/\\]java[/\\]br[/\\]com[/\\]sbk[/\\]sbking[/\\]gui[/\\].*" />
+    <suppress id="non-core" files="[/\\]src[/\\]main[/\\].*[/\\]core[/\\].*" />
+</suppressions>

--- a/pom-client.xml
+++ b/pom-client.xml
@@ -108,7 +108,7 @@
 				<artifactId>maven-checkstyle-plugin</artifactId>
 				<version>3.1.2</version>
 				<configuration>
-					<configLocation>sbking_checkstyle.xml</configLocation>
+					<configLocation>checkstyle/sbking_checkstyle.xml</configLocation>
 					<encoding>UTF-8</encoding>
 					<failOnViolation>true</failOnViolation>
 					<enableFilesSummary>false</enableFilesSummary>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 				<artifactId>maven-checkstyle-plugin</artifactId>
 				<version>3.1.2</version>
 				<configuration>
-					<configLocation>sbking_checkstyle.xml</configLocation>
+					<configLocation>checkstyle/sbking_checkstyle.xml</configLocation>
 					<encoding>UTF-8</encoding>
 					<failOnViolation>true</failOnViolation>
 					<enableFilesSummary>false</enableFilesSummary>


### PR DESCRIPTION
This PR changes MagicNumber severity on core files to warning, while keeping non-core files (mostly GUI) severity on MagicNumber as info.