### PR TITLE
[build] organize maven and docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM maven:3.6.3-adoptopenjdk-11 AS MAVEN_TOOL_CHAIN
 WORKDIR /tmp/
-COPY pom.xml /tmp/
-RUN mvn dependency:resolve
+
+COPY pom-ci.xml /tmp/pom.xml
+COPY pom-server.xml /tmp/
+RUN mvn -f pom-server.xml dependency:resolve-plugins dependency:go-offline -B
+
 COPY src /tmp/src/
-COPY checkstyle/ /tmp/checkstyle/
-RUN mvn package
+RUN mvn -f pom-server.xml package -B
 
 FROM adoptopenjdk:11-jre-openj9
 RUN mkdir /opt/app

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,35 @@
-APP_NAME=sbking
+APP_NAME=rulojuka/sbking
+
+all: package
+
+clean:
+	mvn clean
+	rm -f ./sbking-client.jar ./sbking-server.jar
+	docker rmi $(APP_NAME); true
+
+package: server client
+
+server: kill_server package_server copy_server
+
+kill_server:
+	@./kill_sbking_server.sh
+
+package_server:
+	mvn -f pom-server.xml package
+
+copy_server:
+	cp target/sbking-server-1.0.0-alpha-jar-with-dependencies.jar ./sbking-server.jar
+
+client: kill_server package_client copy_client
+
+package_client:
+	mvn -f pom-client.xml package
+
+copy_client:
+	cp target/sbking-client-1.0.0-alpha-jar-with-dependencies.jar ./sbking-client.jar && chmod +x ./sbking-client.jar
 
 build:
 	docker build -t $(APP_NAME) .
 
 run:
 	docker run --rm $(APP_NAME)
-
-clean:
-	docker rmi $(APP_NAME)
-	rm ./sbking-client.jar
-	rm ./sbking-server.jar
-
-kill_server:
-	@./kill_sbking_server.sh
-
-client: kill_server
-	mvn -f pom-client.xml clean package && cp target/sbking-1.0.0-alpha-jar-with-dependencies.jar ./sbking-client.jar && chmod +x ./sbking-client.jar
-
-server: kill_server
-	mvn clean package && cp target/sbking-1.0.0-alpha-jar-with-dependencies.jar ./sbking-server.jar

--- a/pom-ci.xml
+++ b/pom-ci.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>br.com.sbk</groupId>
+  <artifactId>sbking</artifactId>
+  <version>1.0.0-alpha</version>
+  <name>SBKing</name>
+  <description>More information at https://github.com/rulojuka/sbking</description>
+  <packaging>pom</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.27.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.14.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pom-server.xml
+++ b/pom-server.xml
@@ -8,7 +8,7 @@
 		<version>1.0.0-alpha</version>
 		<relativePath>./pom.xml</relativePath>
 	</parent>
-	<artifactId>sbking-client</artifactId>
+	<artifactId>sbking-server</artifactId>
 	<packaging>jar</packaging>
 
 	<build>
@@ -26,7 +26,7 @@
 						<configuration>
 							<archive>
 								<manifest>
-									<mainClass>br.com.sbk.sbking.gui.main.MainNetworkGame</mainClass>
+									<mainClass>br.com.sbk.sbking.networking.server.main.LobbyServerStarter</mainClass>
 								</manifest>
 							</archive>
 							<descriptorRefs>
@@ -38,4 +38,5 @@
 			</plugin>
 		</plugins>
 	</build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>br.com.sbk</groupId>
@@ -9,6 +7,7 @@
 	<version>1.0.0-alpha</version>
 	<name>SBKing</name>
 	<description>More information at https://github.com/rulojuka/sbking</description>
+	<packaging>pom</packaging>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -27,44 +26,15 @@
 			<version>2.27.0</version>
 			<scope>test</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 			<version>2.14.0</version>
 		</dependency>
-
 	</dependencies>
 
 	<build>
 		<plugins>
-
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.2</version>
-				<executions>
-					<execution>
-						<id>jar-with-dependencies</id>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-						<configuration>
-							<archive>
-								<manifest>
-									<mainClass>br.com.sbk.sbking.networking.server.main.LobbyServerStarter</mainClass>
-								</manifest>
-							</archive>
-							<descriptorRefs>
-								<descriptorRef>jar-with-dependencies</descriptorRef>
-							</descriptorRefs>
-							<!-- <finalName>${project.artifactId}-${project.version}-complete</finalName> -->
-							<!-- <appendAssemblyId>false</appendAssemblyId> -->
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
@@ -96,7 +66,6 @@
 				</executions>
 			</plugin>
 
-
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
@@ -124,7 +93,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
 	</build>
 
@@ -134,7 +102,7 @@
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
-				<version>3.1.12-SNAPSHOT</version>
+				<version>3.1.11</version>
 			</plugin>
 		</plugins>
 	</reporting>


### PR DESCRIPTION
Tried to improve the build a little.

- Improved pom by creating a parent pom and including it on `pom-server.xml` and `pom-client.xml`
- Created a `pom-ci.xml` to avoid additional downloads when building via docker.
- Updated makefile to not clean between server and client builds
- Added the default rule (`make`) that builds server and client
- Improved `Dockerfile` as far as maven let me

Still there are problems:
- Maven does not have a decent download strategy, so it is way too slow to download dependencies
- Maven dependency plugin is not good enough, so its `dependency:go-offline`it is definitely not good enough to go offline
- Because maven sucks, docker cannot cache every step and has to download some of the same dependencies when the code changes.

References to the future:
[How do I configure Maven for offline development?](https://stackoverflow.com/questions/7233328/how-do-i-configure-maven-for-offline-development)
[more on dependency:go-offline](https://stackoverflow.com/questions/43661755/how-to-build-and-release-a-maven-project-from-an-offline-machine-with-a-file-di)
[a plugin that probably fixes go-offline for real](https://github.com/qaware/go-offline-maven-plugin)
[How to point .m2 folder correctly to the docker build and avoid downloading everything again](https://stackoverflow.com/questions/36234088/how-do-i-point-a-docker-image-to-my-m2-directory-for-running-maven-in-docker-on)