### PR TITLE
[feat] Undo

### DIFF
--- a/src/main/java/br/com/sbk/sbking/core/Board.java
+++ b/src/main/java/br/com/sbk/sbking/core/Board.java
@@ -86,4 +86,11 @@ public class Board {
         return true;
     }
 
+    public void putCardInHand(Map<Card, Direction> cardDirectionMap) {
+        for (Map.Entry<Card, Direction> cardDirection : cardDirectionMap.entrySet()) {
+            this.hands.get(cardDirection.getValue()).addCard(cardDirection.getKey());
+            this.hands.get(cardDirection.getValue()).sort();
+        }
+    }
+
 }

--- a/src/main/java/br/com/sbk/sbking/core/Direction.java
+++ b/src/main/java/br/com/sbk/sbking/core/Direction.java
@@ -67,4 +67,12 @@ public enum Direction {
     public Direction getGameModeOrStrainChooserWhenDealer() {
         return this.next(3);
     }
+
+    public static int differenceBetween(Direction leader, Direction direction) {
+        int result = (direction.ordinal() - leader.ordinal()) % vals.length;
+        if (result < 0) {
+            return vals.length + result;
+        }
+        return result;
+    }
 }

--- a/src/main/java/br/com/sbk/sbking/core/Score.java
+++ b/src/main/java/br/com/sbk/sbking/core/Score.java
@@ -42,6 +42,14 @@ public class Score {
         eastWestPoints += this.scoreable.getPoints(trick);
     }
 
+    public void subtractTrickFromDirection(Trick trick, Direction winner) {
+        if (winner.isNorthSouth()) {
+            this.northSouthPoints -= this.scoreable.getPoints(trick);
+        } else {
+            this.eastWestPoints -= this.scoreable.getPoints(trick);
+        }
+    }
+
     public int getAlreadyPlayedPoints() {
         return this.eastWestPoints + this.northSouthPoints;
     }
@@ -91,5 +99,4 @@ public class Score {
         }
         return true;
     }
-
 }

--- a/src/main/java/br/com/sbk/sbking/core/Trick.java
+++ b/src/main/java/br/com/sbk/sbking/core/Trick.java
@@ -5,7 +5,9 @@ import static br.com.sbk.sbking.core.GameConstants.COMPLETE_TRICK_NUMBER_OF_CARD
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -51,6 +53,14 @@ public class Trick {
 
     public List<Card> getCards() {
         return Collections.unmodifiableList(this.cards);
+    }
+
+    public Map<Card, Direction> getCardDirectionMap() {
+        Map<Card, Direction> mapDirectionCard = new HashMap<Card, Direction>();
+        for (Card card : this.cards) {
+            mapDirectionCard.put(card, this.directionOfCard(card));
+        }
+        return mapDirectionCard;
     }
 
     public Suit getLeadSuit() {
@@ -208,6 +218,30 @@ public class Trick {
     @Override
     public String toString() {
         return this.cards.toString();
+    }
+
+    public boolean hasCardOf(Direction direction) {
+        int stepsBetween = Direction.differenceBetween(this.getLeader(), direction);
+        int minNumberOfCardsThatShouldBePlayedForDirectionToBeIncluded = stepsBetween + 1;
+        int numberOfCardsInTable = this.getCards().size();
+        return minNumberOfCardsThatShouldBePlayedForDirectionToBeIncluded <= numberOfCardsInTable;
+    }
+
+    public Map<Card, Direction> getCardsFromLastUpTo(Direction direction) {
+        Map<Card, Direction> cardsUpToDirection = new HashMap<Card, Direction>();
+        int directionPosition = Direction.differenceBetween(this.leader, direction);
+        for (int i = this.cards.size() - 1; i >= directionPosition; i--) {
+            Direction currentDirection = this.directionOfCard(this.cards.get(i));
+            cardsUpToDirection.put(this.cards.get(i), currentDirection);
+        }
+        return cardsUpToDirection;
+    }
+
+    public void removeCardsFromLastUpTo(Direction direction) {
+        int directionIndex = Direction.differenceBetween(this.getLeader(), direction);
+        for (int i = this.cards.size() - 1; i >= directionIndex; i--) {
+            this.cards.remove(i);
+        }
     }
 
 }

--- a/src/main/java/br/com/sbk/sbking/gui/JElements/UndoButton.java
+++ b/src/main/java/br/com/sbk/sbking/gui/JElements/UndoButton.java
@@ -1,0 +1,10 @@
+package br.com.sbk.sbking.gui.JElements;
+
+@SuppressWarnings("serial")
+public class UndoButton extends SBKingButton {
+
+    public UndoButton() {
+        super();
+    }
+
+}

--- a/src/main/java/br/com/sbk/sbking/gui/elements/AllDirectionBoardElements.java
+++ b/src/main/java/br/com/sbk/sbking/gui/elements/AllDirectionBoardElements.java
@@ -20,7 +20,8 @@ public class AllDirectionBoardElements {
 
         new ScoreboardElement(deal, container, new Point(container.getWidth() - 150, 10));
 
-        new TrickElement(deal.getCurrentTrick(), container, new Point(container.getWidth() / 2, container.getHeight() / 2));
+        new TrickElement(deal.getCurrentTrick(), container,
+                new Point(container.getWidth() / 2, container.getHeight() / 2));
 
         new RulesetElement(deal.getRuleset(), container, new Point(150, 10));
     }

--- a/src/main/java/br/com/sbk/sbking/gui/elements/SpecificDirectionBoardElements.java
+++ b/src/main/java/br/com/sbk/sbking/gui/elements/SpecificDirectionBoardElements.java
@@ -34,6 +34,8 @@ public class SpecificDirectionBoardElements {
                 new Point(container.getWidth() / 2, container.getHeight() / 2));
 
         new RulesetElement(deal.getRuleset(), container, new Point(150, 10));
+
+        new UndoElement(container, new Point(150, container.getHeight() - 50), actionListener);
     }
 
 }

--- a/src/main/java/br/com/sbk/sbking/gui/elements/SpecificDirectionWithDummyBoardElements.java
+++ b/src/main/java/br/com/sbk/sbking/gui/elements/SpecificDirectionWithDummyBoardElements.java
@@ -28,6 +28,9 @@ public class SpecificDirectionWithDummyBoardElements {
     new TrickElement(deal.getCurrentTrick(), container, new Point(container.getWidth() / 2, container.getHeight() / 2));
 
     new RulesetElement(deal.getRuleset(), container, new Point(150, 10));
+
+    new UndoElement(container, new Point(150, container.getHeight() - 50), actionListener);
+
   }
 
   private boolean shouldDrawVisible(Direction playerDirection, Direction currentDirection, Direction dummy,

--- a/src/main/java/br/com/sbk/sbking/gui/elements/UndoElement.java
+++ b/src/main/java/br/com/sbk/sbking/gui/elements/UndoElement.java
@@ -1,0 +1,20 @@
+package br.com.sbk.sbking.gui.elements;
+
+import java.awt.Container;
+import java.awt.Point;
+import java.awt.event.ActionListener;
+import javax.swing.JButton;
+import br.com.sbk.sbking.gui.JElements.UndoButton;
+
+public class UndoElement {
+
+    public UndoElement(Container container, Point point, ActionListener actionListener) {
+
+        JButton undoButton = new UndoButton();
+        undoButton.addActionListener(actionListener);
+        undoButton.setText("UNDO");
+        undoButton.setBounds(point.x, point.y, 100, 30);
+        container.add(undoButton);
+    }
+
+}

--- a/src/main/java/br/com/sbk/sbking/gui/listeners/ClientActionListener.java
+++ b/src/main/java/br/com/sbk/sbking/gui/listeners/ClientActionListener.java
@@ -3,6 +3,7 @@ package br.com.sbk.sbking.gui.listeners;
 import br.com.sbk.sbking.core.Card;
 import br.com.sbk.sbking.core.Direction;
 import br.com.sbk.sbking.gui.JElements.CardButton;
+import br.com.sbk.sbking.gui.JElements.UndoButton;
 import br.com.sbk.sbking.gui.JElements.SitOrLeaveButton;
 import br.com.sbk.sbking.networking.kryonet.KryonetSBKingClientActionListener;
 
@@ -31,6 +32,8 @@ public class ClientActionListener implements java.awt.event.ActionListener {
             SitOrLeaveButton clickedSitOrLeaveButton = (SitOrLeaveButton) source;
             Direction direction = (Direction) clickedSitOrLeaveButton.getClientProperty("direction");
             client.sitOrLeave(direction);
+        } else if (source instanceof UndoButton) {
+            client.undo();
         }
     }
 

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingClient.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingClient.java
@@ -16,6 +16,7 @@ import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.ChoosePositi
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.MoveToSeatMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.PlayCardMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.SetNicknameMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.UndoMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.BoardMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.DealMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.FinishDealMessage;
@@ -106,6 +107,10 @@ public class KryonetSBKingClient extends Client {
 
   public void sendChooseGameModeOrStrain(String gameModeOrStrain) {
     this.sendMessage(new ChooseGameModeOrStrainMessage(gameModeOrStrain));
+  }
+
+  public void sendUndo() {
+    this.sendMessage(new UndoMessage());
   }
 
 }

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingClientActionListener.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingClientActionListener.java
@@ -19,4 +19,8 @@ public class KryonetSBKingClientActionListener {
     client.sitOrLeave(direction);
   }
 
+  public void undo() {
+    client.sendUndo();
+  }
+
 }

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingServer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingServer.java
@@ -19,6 +19,7 @@ import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.ChoosePositi
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.MoveToSeatMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.PlayCardMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.SetNicknameMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.UndoMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.BoardMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.DealMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.FinishDealMessage;
@@ -75,6 +76,8 @@ public class KryonetSBKingServer extends Server {
       this.sbkingServer.chooseNegative(playerIdentifier);
     } else if (message instanceof ChooseGameModeOrStrainMessage) {
       this.sbkingServer.chooseGameModeOrStrain((String) content, playerIdentifier);
+    } else if (message instanceof UndoMessage) {
+      this.sbkingServer.undo(playerIdentifier);
     } else {
       LOGGER.error("Could not understand message.");
       LOGGER.error(message);

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetUtils.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetUtils.java
@@ -42,6 +42,7 @@ import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.ChoosePositi
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.MoveToSeatMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.PlayCardMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.SetNicknameMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.UndoMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.BoardMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.DealMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.FinishDealMessage;
@@ -113,6 +114,7 @@ public class KryonetUtils {
     kryo.register(PositiveOrNegativeChooserMessage.class);
     kryo.register(PositiveOrNegativeMessage.class);
     kryo.register(TextMessage.class);
+    kryo.register(UndoMessage.class);
     kryo.register(ValidRulesetMessage.class);
     kryo.register(YourDirectionIsMessage.class);
 

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/messages/ClientToServer/UndoMessage.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/messages/ClientToServer/UndoMessage.java
@@ -1,0 +1,15 @@
+package br.com.sbk.sbking.networking.kryonet.messages.ClientToServer;
+
+import br.com.sbk.sbking.networking.kryonet.messages.SBKingMessage;
+
+public class UndoMessage implements SBKingMessage {
+
+    public UndoMessage() {
+    }
+
+    @Override
+    public String getContent() {
+        return null;
+    }
+
+}

--- a/src/main/java/br/com/sbk/sbking/networking/server/SBKingServer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/server/SBKingServer.java
@@ -171,4 +171,9 @@ public class SBKingServer {
     this.table.addSpectator(new PlayerNetworkInformation(this.identifierToPlayerMap.get(identifier)));
   }
 
+  public void undo(UUID playerIdentifier) {
+    Direction direction = this.playerDirections.get(playerIdentifier);
+    this.table.undo(direction);
+  }
+
 }

--- a/src/main/java/br/com/sbk/sbking/networking/server/Table.java
+++ b/src/main/java/br/com/sbk/sbking/networking/server/Table.java
@@ -178,4 +178,8 @@ public class Table {
     this.getSBKingServer().sendDealAll(this.gameServer.getDeal());
   }
 
+  public void undo(Direction direction) {
+    this.gameServer.undo(direction);
+    this.sendDealAll();
+  }
 }

--- a/src/main/java/br/com/sbk/sbking/networking/server/gameServer/GameServer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/server/gameServer/GameServer.java
@@ -101,4 +101,8 @@ public abstract class GameServer implements Runnable {
         this.getSBKingServer().sendValidRulesetAll();
     }
 
+    public void undo(Direction direction) {
+        this.getDeal().undo(direction);
+    }
+
 }

--- a/src/test/java/br/com/sbk/sbking/core/DirectionTest.java
+++ b/src/test/java/br/com/sbk/sbking/core/DirectionTest.java
@@ -122,4 +122,23 @@ public class DirectionTest {
         assertEquals(WEST_ABBREVIATION, west.getAbbreviation());
     }
 
+    @Test
+    public void differenceBetweenShouldReturnZeroWhenGivenTwoTimesTheSameDirection() {
+        Direction leader = Direction.WEST;
+
+        int result = Direction.differenceBetween(leader, leader);
+
+        assertEquals(0, result);
+    }
+
+    @Test
+    public void differenceBetweenShouldReturnDistanceBetweenTwoNeighbors() {
+        Direction leader = Direction.WEST;
+        Direction direction = Direction.SOUTH;
+        Direction direction2 = Direction.NORTH;
+
+        assertEquals(3, Direction.differenceBetween(leader, direction));
+        assertEquals(1, Direction.differenceBetween(leader, direction2));
+    }
+
 }


### PR DESCRIPTION
The undo feature makes it possible to undo tricks.
For more information about this feature check the issue #24 

This features impacts the scoreboard and also the tricks showed on the game screen, the first because when you undo the trick the points earned need to be removed, and second because the played cards shouldn't appear on the board since they was replaced on the players hands. Just solved both problems.

Didn't created tests yet because I would like to receive feedbacks first.