### PR TITLE
Message queue

### DIFF
--- a/src/main/java/br/com/sbk/sbking/networking/client/SBKingClientFactory.java
+++ b/src/main/java/br/com/sbk/sbking/networking/client/SBKingClientFactory.java
@@ -3,18 +3,28 @@ package br.com.sbk.sbking.networking.client;
 import static br.com.sbk.sbking.logging.SBKingLogger.LOGGER;
 
 import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import br.com.sbk.sbking.core.constants.ErrorCodes;
 import br.com.sbk.sbking.gui.listeners.ClientActionListener;
 import br.com.sbk.sbking.networking.kryonet.KryonetClientFactory;
+import br.com.sbk.sbking.networking.kryonet.KryonetClientListenerFactory;
 import br.com.sbk.sbking.networking.kryonet.KryonetSBKingClient;
 import br.com.sbk.sbking.networking.kryonet.KryonetSBKingClientActionListener;
+import br.com.sbk.sbking.networking.kryonet.SBKingClientMessageConsumer;
+import br.com.sbk.sbking.networking.kryonet.messages.SBKingMessage;
 
 public class SBKingClientFactory {
 
   public static SBKingClient createWithKryonetConnection(String nickname, String hostname, int port) {
     SBKingClient sbKingClient = new SBKingClient();
+    BlockingQueue<SBKingMessage> clientMessageQueue = new LinkedBlockingQueue<SBKingMessage>();
     KryonetSBKingClient kryonetSBKingClient = KryonetClientFactory.getRegisteredClient(sbKingClient);
+    kryonetSBKingClient.addListener(KryonetClientListenerFactory.getClientListener(clientMessageQueue)); // Producer
+    SBKingClientMessageConsumer sbKingClientMessageConsumer = new SBKingClientMessageConsumer(sbKingClient,
+        clientMessageQueue); // Consumer
+    new Thread(sbKingClientMessageConsumer, "msg-consumer").start();
     sbKingClient.setPlayCardActionListener(
         new ClientActionListener(new KryonetSBKingClientActionListener(kryonetSBKingClient)));
     LOGGER.info("Trying to connect.");

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetClientFactory.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetClientFactory.java
@@ -11,7 +11,6 @@ public class KryonetClientFactory {
     // registered by the same method for both the client and server.
     KryonetUtils.register(client);
 
-    client.addListener(KryonetClientListenerFactory.getClientListener(client));
     return client;
   }
 

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingClient.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingClient.java
@@ -4,9 +4,7 @@ import static br.com.sbk.sbking.logging.SBKingLogger.LOGGER;
 
 import com.esotericsoftware.kryonet.Client;
 
-import br.com.sbk.sbking.core.Board;
 import br.com.sbk.sbking.core.Card;
-import br.com.sbk.sbking.core.Deal;
 import br.com.sbk.sbking.core.Direction;
 import br.com.sbk.sbking.networking.client.SBKingClient;
 import br.com.sbk.sbking.networking.kryonet.messages.SBKingMessage;
@@ -17,19 +15,6 @@ import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.MoveToSeatMe
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.PlayCardMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.SetNicknameMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.UndoMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.BoardMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.DealMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.FinishDealMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.GameModeOrStrainChooserMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.InitializeDealMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.InvalidRulesetMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.IsNotSpectatorMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.IsSpectatorMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.PositiveOrNegativeChooserMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.PositiveOrNegativeMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.TextMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.ValidRulesetMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.YourDirectionIsMessage;
 
 public class KryonetSBKingClient extends Client {
 
@@ -37,47 +22,6 @@ public class KryonetSBKingClient extends Client {
 
   public KryonetSBKingClient(SBKingClient sbkingClient) {
     this.sbkingClient = sbkingClient;
-  }
-
-  protected void onMessage(SBKingMessage message) {
-    LOGGER.debug("Entered --onMessage--");
-    Object content = message.getContent();
-    if (message instanceof TextMessage) {
-      LOGGER.info("Received message from server: " + content);
-    } else if (message instanceof BoardMessage) {
-      this.sbkingClient.setCurrentBoard((Board) content);
-    } else if (message instanceof DealMessage) {
-      this.sbkingClient.setCurrentDeal((Deal) content);
-    } else if (message instanceof YourDirectionIsMessage) {
-      this.sbkingClient.initializeDirection((Direction) content);
-    } else if (message instanceof PositiveOrNegativeChooserMessage) {
-      this.sbkingClient.setPositiveOrNegativeChooser((Direction) content);
-    } else if (message instanceof PositiveOrNegativeMessage) {
-      boolean isPositive = (Boolean) content;
-      if (isPositive) {
-        this.sbkingClient.selectedPositive();
-      } else {
-        this.sbkingClient.selectedNegative();
-      }
-    } else if (message instanceof GameModeOrStrainChooserMessage) {
-      this.sbkingClient.setGameModeOrStrainChooser((Direction) content);
-    } else if (message instanceof InitializeDealMessage) {
-      this.sbkingClient.initializeDeal();
-    } else if (message instanceof FinishDealMessage) {
-      this.sbkingClient.finishDeal();
-    } else if (message instanceof InvalidRulesetMessage) {
-      this.sbkingClient.setRulesetValid(false);
-    } else if (message instanceof ValidRulesetMessage) {
-      this.sbkingClient.setRulesetValid(true);
-    } else if (message instanceof IsSpectatorMessage) {
-      this.sbkingClient.setSpectator(true);
-    } else if (message instanceof IsNotSpectatorMessage) {
-      this.sbkingClient.setSpectator(false);
-    } else {
-      LOGGER.error("Could not understand message.");
-      LOGGER.error(message);
-    }
-
   }
 
   private void sendMessage(SBKingMessage message) {

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingServer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingServer.java
@@ -9,17 +9,9 @@ import java.util.UUID;
 import com.esotericsoftware.kryonet.Server;
 
 import br.com.sbk.sbking.core.Board;
-import br.com.sbk.sbking.core.Card;
 import br.com.sbk.sbking.core.Deal;
 import br.com.sbk.sbking.core.Direction;
 import br.com.sbk.sbking.networking.kryonet.messages.SBKingMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.ChooseGameModeOrStrainMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.ChooseNegativeMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.ChoosePositiveMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.MoveToSeatMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.PlayCardMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.SetNicknameMessage;
-import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.UndoMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.BoardMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.DealMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.FinishDealMessage;
@@ -36,11 +28,12 @@ import br.com.sbk.sbking.networking.server.SBKingServer;
 
 public class KryonetSBKingServer extends Server {
 
-  private List<ConnectionWithIdentifier> connections = new ArrayList<ConnectionWithIdentifier>();
+  private List<ConnectionWithIdentifier> connections;
   private SBKingServer sbkingServer;
 
   public KryonetSBKingServer(SBKingServer sbkingServer) {
     this.sbkingServer = sbkingServer;
+    this.connections = new ArrayList<ConnectionWithIdentifier>();
   }
 
   public void addConnection(ConnectionWithIdentifier connectionWithIdentifier) {
@@ -53,30 +46,6 @@ public class KryonetSBKingServer extends Server {
   public void removeConnection(ConnectionWithIdentifier connectionWithIdentifier) {
     this.connections.remove(connectionWithIdentifier);
     this.sbkingServer.removePlayer(connectionWithIdentifier.getIdentifier());
-  }
-
-  protected void onMessage(SBKingMessage message, ConnectionWithIdentifier connectionWithIdentifier) {
-    LOGGER.debug("Entered --onMessage--");
-    Object content = message.getContent();
-    UUID playerIdentifier = connectionWithIdentifier.getIdentifier();
-    if (message instanceof SetNicknameMessage) {
-      this.sbkingServer.setNickname(playerIdentifier, (String) content);
-    } else if (message instanceof PlayCardMessage) {
-      this.sbkingServer.play((Card) content, playerIdentifier);
-    } else if (message instanceof MoveToSeatMessage) {
-      this.sbkingServer.moveToSeat((Direction) content, playerIdentifier);
-    } else if (message instanceof ChoosePositiveMessage) {
-      this.sbkingServer.choosePositive(playerIdentifier);
-    } else if (message instanceof ChooseNegativeMessage) {
-      this.sbkingServer.chooseNegative(playerIdentifier);
-    } else if (message instanceof ChooseGameModeOrStrainMessage) {
-      this.sbkingServer.chooseGameModeOrStrain((String) content, playerIdentifier);
-    } else if (message instanceof UndoMessage) {
-      this.sbkingServer.undo(playerIdentifier);
-    } else {
-      LOGGER.error("Could not understand message.");
-      LOGGER.error(message);
-    }
   }
 
   private void sendOneTo(SBKingMessage message, UUID playerIdentifier) {

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetServerListenerFactory.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetServerListenerFactory.java
@@ -16,7 +16,8 @@ import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.TextMessage;
 
 public class KryonetServerListenerFactory {
 
-  public static Listener getServerListener(Server server, BlockingQueue<SBKingMessageWithIdentifier> messageQueue) {
+  public static Listener getServerListener(Server server,
+      BlockingQueue<SBKingMessageWithIdentifier> serverMessageQueue) {
     return new Listener() {
       public void connected(Connection connection) {
         LOGGER.debug("Entered --connected-- lifecycle method.");
@@ -94,7 +95,7 @@ public class KryonetServerListenerFactory {
         try {
           SBKingMessageWithIdentifier messageWithIdentifier = new SBKingMessageWithIdentifier(message,
               connectionWithIdentifier.getIdentifier());
-          messageQueue.add(messageWithIdentifier);
+          serverMessageQueue.add(messageWithIdentifier);
         } catch (IllegalStateException e) {
           LOGGER.error("Could not add message to the queue because of insuficcient space. Dropping message:");
           LOGGER.error(message);

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/SBKingClientMessageConsumer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/SBKingClientMessageConsumer.java
@@ -1,0 +1,91 @@
+package br.com.sbk.sbking.networking.kryonet;
+
+import static br.com.sbk.sbking.logging.SBKingLogger.LOGGER;
+
+import java.util.concurrent.BlockingQueue;
+
+import br.com.sbk.sbking.core.Board;
+import br.com.sbk.sbking.core.Deal;
+import br.com.sbk.sbking.core.Direction;
+import br.com.sbk.sbking.networking.client.SBKingClient;
+import br.com.sbk.sbking.networking.kryonet.messages.SBKingMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.BoardMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.DealMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.FinishDealMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.GameModeOrStrainChooserMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.InitializeDealMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.InvalidRulesetMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.IsNotSpectatorMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.IsSpectatorMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.PositiveOrNegativeChooserMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.PositiveOrNegativeMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.TextMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.ValidRulesetMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ServerToClient.YourDirectionIsMessage;
+
+public class SBKingClientMessageConsumer implements Runnable {
+
+  private SBKingClient sbkingClient;
+  private BlockingQueue<SBKingMessage> clientMessageQueue;
+
+  public SBKingClientMessageConsumer(SBKingClient sbkingClient, BlockingQueue<SBKingMessage> clientMessageQueue) {
+    this.sbkingClient = sbkingClient;
+    this.clientMessageQueue = clientMessageQueue;
+  }
+
+  @Override
+  public void run() {
+    try {
+      while (true) {
+        // BlockingQueue.take() blocks until a message is available.
+        SBKingMessage message = clientMessageQueue.take();
+        this.consume(message);
+      }
+    } catch (InterruptedException e) {
+      LOGGER.fatal("Interrupted exception");
+      LOGGER.fatal(e);
+    }
+  }
+
+  private void consume(SBKingMessage message) {
+    LOGGER.debug("Entered --onMessage--");
+    Object content = message.getContent();
+    if (message instanceof TextMessage) {
+      LOGGER.info("Received message from server: " + content);
+    } else if (message instanceof BoardMessage) {
+      this.sbkingClient.setCurrentBoard((Board) content);
+    } else if (message instanceof DealMessage) {
+      this.sbkingClient.setCurrentDeal((Deal) content);
+    } else if (message instanceof YourDirectionIsMessage) {
+      this.sbkingClient.initializeDirection((Direction) content);
+    } else if (message instanceof PositiveOrNegativeChooserMessage) {
+      this.sbkingClient.setPositiveOrNegativeChooser((Direction) content);
+    } else if (message instanceof PositiveOrNegativeMessage) {
+      boolean isPositive = (Boolean) content;
+      if (isPositive) {
+        this.sbkingClient.selectedPositive();
+      } else {
+        this.sbkingClient.selectedNegative();
+      }
+    } else if (message instanceof GameModeOrStrainChooserMessage) {
+      this.sbkingClient.setGameModeOrStrainChooser((Direction) content);
+    } else if (message instanceof InitializeDealMessage) {
+      this.sbkingClient.initializeDeal();
+    } else if (message instanceof FinishDealMessage) {
+      this.sbkingClient.finishDeal();
+    } else if (message instanceof InvalidRulesetMessage) {
+      this.sbkingClient.setRulesetValid(false);
+    } else if (message instanceof ValidRulesetMessage) {
+      this.sbkingClient.setRulesetValid(true);
+    } else if (message instanceof IsSpectatorMessage) {
+      this.sbkingClient.setSpectator(true);
+    } else if (message instanceof IsNotSpectatorMessage) {
+      this.sbkingClient.setSpectator(false);
+    } else {
+      LOGGER.error("Could not understand message.");
+      LOGGER.error(message);
+    }
+
+  }
+
+}

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/SBKingServerMessageConsumer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/SBKingServerMessageConsumer.java
@@ -1,0 +1,70 @@
+package br.com.sbk.sbking.networking.kryonet;
+
+import static br.com.sbk.sbking.logging.SBKingLogger.LOGGER;
+
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+
+import br.com.sbk.sbking.core.Card;
+import br.com.sbk.sbking.core.Direction;
+import br.com.sbk.sbking.networking.kryonet.messages.SBKingMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.SBKingMessageWithIdentifier;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.ChooseGameModeOrStrainMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.ChooseNegativeMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.ChoosePositiveMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.MoveToSeatMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.PlayCardMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.SetNicknameMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.UndoMessage;
+import br.com.sbk.sbking.networking.server.SBKingServer;
+
+public class SBKingServerMessageConsumer implements Runnable {
+
+  private SBKingServer sbkingServer;
+  private BlockingQueue<SBKingMessageWithIdentifier> messageQueue;
+
+  public SBKingServerMessageConsumer(SBKingServer sbkingServer,
+      BlockingQueue<SBKingMessageWithIdentifier> messageQueue) {
+    this.sbkingServer = sbkingServer;
+    this.messageQueue = messageQueue;
+  }
+
+  @Override
+  public void run() {
+    try {
+      while (true) {
+        // BlockingQueue.take() blocks until a message is available.
+        SBKingMessageWithIdentifier messageWithIdentifier = messageQueue.take();
+        this.consume(messageWithIdentifier.getMessage(), messageWithIdentifier.getIdentifier());
+      }
+    } catch (InterruptedException e) {
+      LOGGER.fatal("Interrupted exception");
+      LOGGER.fatal(e);
+    }
+
+  }
+
+  private void consume(SBKingMessage message, UUID playerIdentifier) {
+    LOGGER.debug("Entered server --consume--");
+    Object content = message.getContent();
+    if (message instanceof SetNicknameMessage) {
+      this.sbkingServer.setNickname(playerIdentifier, (String) content);
+    } else if (message instanceof PlayCardMessage) {
+      this.sbkingServer.play((Card) content, playerIdentifier);
+    } else if (message instanceof MoveToSeatMessage) {
+      this.sbkingServer.moveToSeat((Direction) content, playerIdentifier);
+    } else if (message instanceof ChoosePositiveMessage) {
+      this.sbkingServer.choosePositive(playerIdentifier);
+    } else if (message instanceof ChooseNegativeMessage) {
+      this.sbkingServer.chooseNegative(playerIdentifier);
+    } else if (message instanceof ChooseGameModeOrStrainMessage) {
+      this.sbkingServer.chooseGameModeOrStrain((String) content, playerIdentifier);
+    } else if (message instanceof UndoMessage) {
+      this.sbkingServer.undo(playerIdentifier);
+    } else {
+      LOGGER.error("Could not understand message.");
+      LOGGER.error(message);
+    }
+  }
+
+}

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/SBKingServerMessageConsumer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/SBKingServerMessageConsumer.java
@@ -21,12 +21,12 @@ import br.com.sbk.sbking.networking.server.SBKingServer;
 public class SBKingServerMessageConsumer implements Runnable {
 
   private SBKingServer sbkingServer;
-  private BlockingQueue<SBKingMessageWithIdentifier> messageQueue;
+  private BlockingQueue<SBKingMessageWithIdentifier> serverMessageQueue;
 
   public SBKingServerMessageConsumer(SBKingServer sbkingServer,
-      BlockingQueue<SBKingMessageWithIdentifier> messageQueue) {
+      BlockingQueue<SBKingMessageWithIdentifier> serverMessageQueue) {
     this.sbkingServer = sbkingServer;
-    this.messageQueue = messageQueue;
+    this.serverMessageQueue = serverMessageQueue;
   }
 
   @Override
@@ -34,7 +34,7 @@ public class SBKingServerMessageConsumer implements Runnable {
     try {
       while (true) {
         // BlockingQueue.take() blocks until a message is available.
-        SBKingMessageWithIdentifier messageWithIdentifier = messageQueue.take();
+        SBKingMessageWithIdentifier messageWithIdentifier = serverMessageQueue.take();
         this.consume(messageWithIdentifier.getMessage(), messageWithIdentifier.getIdentifier());
       }
     } catch (InterruptedException e) {

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/messages/SBKingMessageWithIdentifier.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/messages/SBKingMessageWithIdentifier.java
@@ -1,0 +1,23 @@
+package br.com.sbk.sbking.networking.kryonet.messages;
+
+import java.util.UUID;
+
+public class SBKingMessageWithIdentifier {
+
+  private SBKingMessage message;
+  private UUID identifier;
+
+  public SBKingMessageWithIdentifier(SBKingMessage message, UUID identifier) {
+    this.message = message;
+    this.identifier = identifier;
+  }
+
+  public SBKingMessage getMessage() {
+    return message;
+  }
+
+  public UUID getIdentifier() {
+    return identifier;
+  }
+
+}

--- a/src/main/java/br/com/sbk/sbking/networking/server/LobbyServer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/server/LobbyServer.java
@@ -2,7 +2,6 @@ package br.com.sbk.sbking.networking.server;
 
 import static br.com.sbk.sbking.logging.SBKingLogger.LOGGER;
 
-import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -10,9 +9,6 @@ import br.com.sbk.sbking.core.constants.ErrorCodes;
 import br.com.sbk.sbking.networking.core.properties.FileProperties;
 import br.com.sbk.sbking.networking.core.properties.NetworkingProperties;
 import br.com.sbk.sbking.networking.core.properties.SystemProperties;
-import br.com.sbk.sbking.networking.kryonet.KryonetSBKingServer;
-import br.com.sbk.sbking.networking.kryonet.KryonetServerFactory;
-import br.com.sbk.sbking.networking.kryonet.KryonetServerListenerFactory;
 import br.com.sbk.sbking.networking.server.gameServer.GameServer;
 import br.com.sbk.sbking.networking.server.gameServer.MinibridgeGameServer;
 
@@ -39,25 +35,9 @@ public class LobbyServer {
         this.table = new Table(gameServer);
         gameServer.setTable(this.table);
 
-        // kryonet code
-        SBKingServer sbKingServer = new SBKingServer(this.table);
-        KryonetSBKingServer server = KryonetServerFactory.getRegisteredServer(sbKingServer);
-        server.addListener(KryonetServerListenerFactory.getServerListener(server));
-        try {
-            server.bind(port);
-        } catch (IOException e1) {
-            LOGGER.fatal("Could not bind port.");
-        }
-        server.start();
-
-        // bindings
-        gameServer.setSBKingServer(sbKingServer);
-        sbKingServer.setKryonetSBKingServer(server);
-
-        // end of kryonet code
+        SBKingServerFactory.createWithKryonetConnection(this.table, port, gameServer);
 
         pool.execute(gameServer);
-
     }
 
     private int getPortFromNetworkingProperties() {

--- a/src/main/java/br/com/sbk/sbking/networking/server/SBKingServerFactory.java
+++ b/src/main/java/br/com/sbk/sbking/networking/server/SBKingServerFactory.java
@@ -1,0 +1,46 @@
+package br.com.sbk.sbking.networking.server;
+
+import static br.com.sbk.sbking.logging.SBKingLogger.LOGGER;
+
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import com.esotericsoftware.kryonet.Listener;
+
+import br.com.sbk.sbking.networking.kryonet.KryonetSBKingServer;
+import br.com.sbk.sbking.networking.kryonet.KryonetServerFactory;
+import br.com.sbk.sbking.networking.kryonet.KryonetServerListenerFactory;
+import br.com.sbk.sbking.networking.kryonet.SBKingServerMessageConsumer;
+import br.com.sbk.sbking.networking.kryonet.messages.SBKingMessageWithIdentifier;
+import br.com.sbk.sbking.networking.server.gameServer.GameServer;
+
+public class SBKingServerFactory {
+
+  public static SBKingServer createWithKryonetConnection(Table table, int port, GameServer gameServer) {
+    SBKingServer sbKingServer = new SBKingServer(table);
+    BlockingQueue<SBKingMessageWithIdentifier> messageQueue = new LinkedBlockingQueue<SBKingMessageWithIdentifier>();
+    KryonetSBKingServer server = KryonetServerFactory.getRegisteredServer(sbKingServer);
+
+    Listener kryonetServerListener = KryonetServerListenerFactory.getServerListener(server, messageQueue); // Producer
+    SBKingServerMessageConsumer sbKingServerMessageConsumer = new SBKingServerMessageConsumer(sbKingServer,
+        messageQueue); // Consumer
+
+    new Thread(sbKingServerMessageConsumer, "msg-consumer").start();
+    server.addListener(kryonetServerListener);
+
+    try {
+      server.bind(port);
+    } catch (IOException e1) {
+      LOGGER.fatal("Could not bind port.");
+    }
+    server.start();
+
+    // bindings
+    gameServer.setSBKingServer(sbKingServer);
+    sbKingServer.setKryonetSBKingServer(server);
+
+    return sbKingServer;
+  }
+
+}

--- a/src/main/java/br/com/sbk/sbking/networking/server/SBKingServerFactory.java
+++ b/src/main/java/br/com/sbk/sbking/networking/server/SBKingServerFactory.java
@@ -19,12 +19,12 @@ public class SBKingServerFactory {
 
   public static SBKingServer createWithKryonetConnection(Table table, int port, GameServer gameServer) {
     SBKingServer sbKingServer = new SBKingServer(table);
-    BlockingQueue<SBKingMessageWithIdentifier> messageQueue = new LinkedBlockingQueue<SBKingMessageWithIdentifier>();
+    BlockingQueue<SBKingMessageWithIdentifier> serverMessageQueue = new LinkedBlockingQueue<SBKingMessageWithIdentifier>();
     KryonetSBKingServer server = KryonetServerFactory.getRegisteredServer(sbKingServer);
 
-    Listener kryonetServerListener = KryonetServerListenerFactory.getServerListener(server, messageQueue); // Producer
+    Listener kryonetServerListener = KryonetServerListenerFactory.getServerListener(server, serverMessageQueue); // Producer
     SBKingServerMessageConsumer sbKingServerMessageConsumer = new SBKingServerMessageConsumer(sbKingServer,
-        messageQueue); // Consumer
+        serverMessageQueue); // Consumer
 
     new Thread(sbKingServerMessageConsumer, "msg-consumer").start();
     server.addListener(kryonetServerListener);


### PR DESCRIPTION
Closes #66
Closes #58

Note on reviewing: This PR is probably best reviewed by commits instead of reviewed by files changed.

This PR adds a [Consumer/Producer](https://en.wikipedia.org/wiki/Producer%E2%80%93consumer_problem) model of concurrency to read messages. From now on, every message received (this happens both on server and clients) will go to a `Queue` and will be consumed sometime in the future. This enables all `SBKingClient` and `SBKingServer` to remaind thread unsafe, as there will be only one Thread acessing it at any time.

A `LinkedBlockingQueue` was used.
`LinkedList` because we don't need random access.
`Blocking` to pass the responsibility of sleeping and awakening the Thread to the List itself. This way, there is not even need for a `Thread.sleep()` inside of the `while(true)` loops.

To test that the queue really works, you can put a breakpoint on the consumer, then trigger many messages on the other side of the network and check that in the next passage through the breakpoint, the queue will have all the messages waiting to be consumed.

Also, after this, there is a high probability that nearly **all** `Thread.sleep()`s in the code are now useless and [should be removed to improve usability](https://github.com/rulojuka/sbking/issues/82)!!!

Finally, this gives us the confidence to deploy the kryonet code to the current servers :)