### PR TITLE
[feat] LobbyScreen with tableCards + joinTable + leaveTable

### DIFF
--- a/src/main/java/br/com/sbk/sbking/gui/JElements/JoinTableButton.java
+++ b/src/main/java/br/com/sbk/sbking/gui/JElements/JoinTableButton.java
@@ -1,0 +1,14 @@
+package br.com.sbk.sbking.gui.JElements;
+
+import java.util.UUID;
+
+public class JoinTableButton extends SBKingButton {
+
+  public JoinTableButton(UUID tableId) {
+    super();
+    this.putClientProperty("type", "JOINTABLE");
+    this.putClientProperty("tableId", tableId);
+    this.setText("Spectate!");
+    this.setSize(160, 20);
+  }
+}

--- a/src/main/java/br/com/sbk/sbking/gui/JElements/LeaveTableButton.java
+++ b/src/main/java/br/com/sbk/sbking/gui/JElements/LeaveTableButton.java
@@ -1,0 +1,11 @@
+package br.com.sbk.sbking.gui.JElements;
+
+public class LeaveTableButton extends SBKingButton {
+
+  public LeaveTableButton() {
+    super();
+    this.putClientProperty("type", "LEAVETABLE");
+    this.setText("Leave Table");
+    this.setSize(140, 20);
+  }
+}

--- a/src/main/java/br/com/sbk/sbking/gui/elements/AllDirectionBoardElements.java
+++ b/src/main/java/br/com/sbk/sbking/gui/elements/AllDirectionBoardElements.java
@@ -24,6 +24,8 @@ public class AllDirectionBoardElements {
                 new Point(container.getWidth() / 2, container.getHeight() / 2));
 
         new RulesetElement(deal.getRuleset(), container, new Point(150, 10));
+
+        new LeaveTableElement(container, new Point(150, 50), actionListener);
     }
 
 }

--- a/src/main/java/br/com/sbk/sbking/gui/elements/AllTableCardsElement.java
+++ b/src/main/java/br/com/sbk/sbking/gui/elements/AllTableCardsElement.java
@@ -1,0 +1,20 @@
+package br.com.sbk.sbking.gui.elements;
+
+import java.awt.event.ActionListener;
+import java.awt.Container;
+import java.awt.Point;
+import java.util.List;
+
+import br.com.sbk.sbking.dto.LobbyScreenTableDTO;
+
+public class AllTableCardsElement {
+
+  public AllTableCardsElement(Container container, List<LobbyScreenTableDTO> tables, ActionListener actionListener) {
+    Point position = new Point(0, 0);
+    for (LobbyScreenTableDTO table : tables) {
+      new TableCardElement(container, table, (Point) position.clone(), actionListener);
+      position.translate(200, 0);
+    }
+  }
+
+}

--- a/src/main/java/br/com/sbk/sbking/gui/elements/LeaveTableElement.java
+++ b/src/main/java/br/com/sbk/sbking/gui/elements/LeaveTableElement.java
@@ -1,0 +1,20 @@
+package br.com.sbk.sbking.gui.elements;
+
+import java.awt.Container;
+import java.awt.Point;
+import java.awt.event.ActionListener;
+
+import javax.swing.JButton;
+
+import br.com.sbk.sbking.gui.JElements.LeaveTableButton;
+
+public class LeaveTableElement {
+
+  public LeaveTableElement(Container container, Point point, ActionListener actionListener) {
+    JButton leaveTableButton = new LeaveTableButton();
+    leaveTableButton.addActionListener(actionListener);
+    leaveTableButton.setLocation(point);
+    container.add(leaveTableButton);
+  }
+
+}

--- a/src/main/java/br/com/sbk/sbking/gui/elements/SpecificDirectionBoardElements.java
+++ b/src/main/java/br/com/sbk/sbking/gui/elements/SpecificDirectionBoardElements.java
@@ -36,6 +36,8 @@ public class SpecificDirectionBoardElements {
         new RulesetElement(deal.getRuleset(), container, new Point(150, 10));
 
         new UndoElement(container, new Point(150, container.getHeight() - 50), actionListener);
+
+        new LeaveTableElement(container, new Point(150, 50), actionListener);
     }
 
 }

--- a/src/main/java/br/com/sbk/sbking/gui/elements/SpecificDirectionWithDummyBoardElements.java
+++ b/src/main/java/br/com/sbk/sbking/gui/elements/SpecificDirectionWithDummyBoardElements.java
@@ -31,6 +31,8 @@ public class SpecificDirectionWithDummyBoardElements {
 
     new UndoElement(container, new Point(150, container.getHeight() - 50), actionListener);
 
+    new LeaveTableElement(container, new Point(150, 50), actionListener);
+
   }
 
   private boolean shouldDrawVisible(Direction playerDirection, Direction currentDirection, Direction dummy,

--- a/src/main/java/br/com/sbk/sbking/gui/elements/TableCardElement.java
+++ b/src/main/java/br/com/sbk/sbking/gui/elements/TableCardElement.java
@@ -1,0 +1,67 @@
+package br.com.sbk.sbking.gui.elements;
+
+import java.awt.event.ActionListener;
+import java.awt.Container;
+import java.awt.Point;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.swing.JLabel;
+
+import br.com.sbk.sbking.core.Direction;
+import br.com.sbk.sbking.core.Player;
+import br.com.sbk.sbking.dto.LobbyScreenTableDTO;
+import br.com.sbk.sbking.gui.JElements.JoinTableButton;
+import br.com.sbk.sbking.gui.JElements.SBKingLabel;
+
+public class TableCardElement {
+
+  public TableCardElement(Container container, LobbyScreenTableDTO table, Point position,
+      ActionListener actionListener) {
+    List<String> allLines = new ArrayList<String>();
+    Map<Direction, Player> playersDirection = table.getPlayersDirection();
+
+    String title = table.getGameName();
+    allLines.add(title);
+
+    for (Direction direction : Direction.values()) {
+      String playerName;
+      Player player = playersDirection.get(direction);
+      if (player == null) {
+        playerName = "EMPTY";
+      } else {
+        playerName = player.getNickname();
+      }
+      String playerLine = direction.getAbbreviation() + ": " + playerName;
+      allLines.add(playerLine);
+    }
+
+    String footer = table.getNumberOfSpectators() + " spectators";
+    allLines.add(footer);
+
+    addAllLabels(container, position, allLines);
+    addJoinButton(container, position, table.getId(), actionListener);
+  }
+
+  private void addAllLabels(Container container, Point position, List<String> allLines) {
+    int labelWidth = 160;
+    int elementHeight = 20;
+    for (String string : allLines) {
+      JLabel waitingLabel = new SBKingLabel(string);
+      waitingLabel.setSize(labelWidth, elementHeight);
+      waitingLabel.setLocation(position);
+      position.translate(0, elementHeight);
+      container.add(waitingLabel);
+    }
+  }
+
+  private void addJoinButton(Container container, Point position, UUID tableId, ActionListener actionListener) {
+    JoinTableButton joinTableButton = new JoinTableButton(tableId);
+    joinTableButton.setLocation(position);
+    joinTableButton.addActionListener(actionListener);
+    container.add(joinTableButton);
+  }
+
+}

--- a/src/main/java/br/com/sbk/sbking/gui/elements/UndoElement.java
+++ b/src/main/java/br/com/sbk/sbking/gui/elements/UndoElement.java
@@ -13,7 +13,7 @@ public class UndoElement {
         JButton undoButton = new UndoButton();
         undoButton.addActionListener(actionListener);
         undoButton.setText("UNDO");
-        undoButton.setBounds(point.x, point.y, 100, 30);
+        undoButton.setBounds(point.x, point.y, 140, 30);
         container.add(undoButton);
     }
 

--- a/src/main/java/br/com/sbk/sbking/gui/listeners/ClientActionListener.java
+++ b/src/main/java/br/com/sbk/sbking/gui/listeners/ClientActionListener.java
@@ -1,10 +1,14 @@
 package br.com.sbk.sbking.gui.listeners;
 
+import java.util.UUID;
+
 import br.com.sbk.sbking.core.Card;
 import br.com.sbk.sbking.core.Direction;
 import br.com.sbk.sbking.gui.JElements.CardButton;
-import br.com.sbk.sbking.gui.JElements.UndoButton;
+import br.com.sbk.sbking.gui.JElements.JoinTableButton;
+import br.com.sbk.sbking.gui.JElements.LeaveTableButton;
 import br.com.sbk.sbking.gui.JElements.SitOrLeaveButton;
+import br.com.sbk.sbking.gui.JElements.UndoButton;
 import br.com.sbk.sbking.networking.kryonet.KryonetSBKingClientActionListener;
 
 public class ClientActionListener implements java.awt.event.ActionListener {
@@ -34,6 +38,12 @@ public class ClientActionListener implements java.awt.event.ActionListener {
             client.sitOrLeave(direction);
         } else if (source instanceof UndoButton) {
             client.undo();
+        } else if (source instanceof JoinTableButton) {
+            JoinTableButton button = (JoinTableButton) source;
+            UUID tableId = (UUID) button.getClientProperty("tableId");
+            client.joinTable(tableId);
+        } else if (source instanceof LeaveTableButton) {
+            client.leaveTable();
         }
     }
 

--- a/src/main/java/br/com/sbk/sbking/gui/main/MainNetworkGame.java
+++ b/src/main/java/br/com/sbk/sbking/gui/main/MainNetworkGame.java
@@ -21,40 +21,35 @@ public class MainNetworkGame {
         welcomeScreen.runAt(sbkingClientJFrame);
 
         SBKingClient sbkingClient = welcomeScreen.getSBKingClient();
-
         SBKingScreen currentScreen;
 
-        currentScreen = new LobbyScreen(sbkingClient);
-        currentScreen.runAt(sbkingClientJFrame);
+        while (true) {
 
-        while (sbkingClient.getGameName() == null) {
-            sleepFor(100);
-        }
+            String gameName = sbkingClient.getGameName();
+            if (gameName == null) {
+                sbkingClient.setTables(null);
+            }
 
-        Class<? extends GameScreen> gameScreenClass = GameScreenFromGameNameIdentifier
-                .identify(sbkingClient.getGameName());
-        GameScreen gameScreen;
-        try {
-            Class[] constructorArguments = new Class[1];
-            constructorArguments[0] = SBKingClient.class;
-            gameScreen = gameScreenClass.getDeclaredConstructor(constructorArguments).newInstance(sbkingClient);
-            LOGGER.info("Created GameScreen:" + gameScreen.getClass());
-            currentScreen = gameScreen;
+            currentScreen = new LobbyScreen(sbkingClient);
             currentScreen.runAt(sbkingClientJFrame);
-        } catch (Exception e) {
-            LOGGER.fatal("Could not initialize GameScreen with received gameScreenClass.");
-            LOGGER.fatal(e);
-            System.exit(ErrorCodes.COULD_NOT_INITIALIZE_GAMESCREEN);
-        }
 
-        LOGGER.info("Exiting main thread.");
-    }
+            LOGGER.info("Finished Lobby Screen, creating table screen");
 
-    private static void sleepFor(int miliseconds) {
-        try {
-            Thread.sleep(miliseconds);
-        } catch (InterruptedException e) {
-            LOGGER.debug(e);
+            Class<? extends GameScreen> gameScreenClass = GameScreenFromGameNameIdentifier
+                    .identify(sbkingClient.getGameName());
+            GameScreen gameScreen;
+            try {
+                Class[] constructorArguments = new Class[1];
+                constructorArguments[0] = SBKingClient.class;
+                gameScreen = gameScreenClass.getDeclaredConstructor(constructorArguments).newInstance(sbkingClient);
+                LOGGER.info("Created GameScreen:" + gameScreen.getClass());
+                currentScreen = gameScreen;
+                currentScreen.runAt(sbkingClientJFrame);
+            } catch (Exception e) {
+                LOGGER.fatal("Could not initialize GameScreen with received gameScreenClass.");
+                LOGGER.fatal(e);
+                System.exit(ErrorCodes.COULD_NOT_INITIALIZE_GAMESCREEN);
+            }
         }
     }
 

--- a/src/main/java/br/com/sbk/sbking/gui/painters/DealPainter.java
+++ b/src/main/java/br/com/sbk/sbking/gui/painters/DealPainter.java
@@ -5,10 +5,8 @@ import static br.com.sbk.sbking.logging.SBKingLogger.LOGGER;
 import java.awt.Container;
 import java.awt.event.ActionListener;
 
-import br.com.sbk.sbking.core.Board;
 import br.com.sbk.sbking.core.Deal;
 import br.com.sbk.sbking.core.Direction;
-import br.com.sbk.sbking.core.rulesets.concrete.NoRuleset;
 import br.com.sbk.sbking.gui.elements.SpecificDirectionBoardElements;
 
 public class DealPainter implements Painter {
@@ -21,12 +19,6 @@ public class DealPainter implements Painter {
         this.actionListener = actionListener;
         this.direction = direction;
         this.deal = deal;
-    }
-
-    public DealPainter(ActionListener actionListener, Direction direction, Board board) {
-        this.actionListener = actionListener;
-        this.direction = direction;
-        this.deal = new Deal(board, new NoRuleset(), null);
     }
 
     @Override

--- a/src/main/java/br/com/sbk/sbking/gui/painters/DealWithDummyPainter.java
+++ b/src/main/java/br/com/sbk/sbking/gui/painters/DealWithDummyPainter.java
@@ -5,7 +5,6 @@ import static br.com.sbk.sbking.logging.SBKingLogger.LOGGER;
 import java.awt.Container;
 import java.awt.event.ActionListener;
 
-import br.com.sbk.sbking.core.Board;
 import br.com.sbk.sbking.core.Deal;
 import br.com.sbk.sbking.core.Direction;
 import br.com.sbk.sbking.gui.elements.SpecificDirectionWithDummyBoardElements;
@@ -18,13 +17,6 @@ public class DealWithDummyPainter extends DealPainter {
   public DealWithDummyPainter(ActionListener actionListener, Direction direction, Deal deal, Direction dummy,
       boolean dummyVisible) {
     super(actionListener, direction, deal);
-    this.dummy = dummy;
-    this.dummyVisible = dummyVisible;
-  }
-
-  public DealWithDummyPainter(ActionListener actionListener, Direction direction, Board board, Direction dummy,
-      boolean dummyVisible) {
-    super(actionListener, direction, board);
     this.dummy = dummy;
     this.dummyVisible = dummyVisible;
   }

--- a/src/main/java/br/com/sbk/sbking/gui/painters/LobbyScreenPainter.java
+++ b/src/main/java/br/com/sbk/sbking/gui/painters/LobbyScreenPainter.java
@@ -1,21 +1,25 @@
 package br.com.sbk.sbking.gui.painters;
 
 import java.awt.Container;
+import java.awt.event.ActionListener;
+import java.util.List;
 
-import br.com.sbk.sbking.gui.elements.CreateTableElement;
-import br.com.sbk.sbking.networking.client.SBKingClient;
+import br.com.sbk.sbking.dto.LobbyScreenTableDTO;
+import br.com.sbk.sbking.gui.elements.AllTableCardsElement;
 
 public class LobbyScreenPainter implements Painter {
 
-  private SBKingClient sbKingClient;
+  private List<LobbyScreenTableDTO> tables;
+  private ActionListener actionListener;
 
-  public LobbyScreenPainter(SBKingClient sbKingClient) {
-    this.sbKingClient = sbKingClient;
+  public LobbyScreenPainter(List<LobbyScreenTableDTO> tables, ActionListener actionListener) {
+    this.tables = tables;
+    this.actionListener = actionListener;
   }
 
   @Override
   public void paint(Container contentPane) {
-    new CreateTableElement(contentPane, this.sbKingClient);
+    new AllTableCardsElement(contentPane, this.tables, this.actionListener);
 
     contentPane.validate();
     contentPane.repaint();

--- a/src/main/java/br/com/sbk/sbking/gui/painters/PainterFactory.java
+++ b/src/main/java/br/com/sbk/sbking/gui/painters/PainterFactory.java
@@ -16,16 +16,16 @@ public class PainterFactory {
     this.sbkingClient = sbkingClient;
   }
 
-  public Painter getDealPainter(Deal deal, Direction direction, ActionListener playCardActionListener) {
-    return new DealPainter(playCardActionListener, direction, deal);
+  public Painter getDealPainter(Deal deal, Direction direction, ActionListener actionListener) {
+    return new DealPainter(actionListener, direction, deal);
   }
 
-  public Painter getSpectatorPainter(Deal deal, ActionListener playCardActionListener) {
+  public Painter getSpectatorPainter(Deal deal, ActionListener actionListener) {
     if (deal == null) {
       LOGGER.error("Deal should not be null here.");
       return null;
     } else {
-      return new SpectatorPainter(playCardActionListener, deal);
+      return new SpectatorPainter(actionListener, deal);
     }
   }
 
@@ -40,10 +40,10 @@ public class PainterFactory {
         this.sbkingClient.getCurrentGameScoreboard());
   }
 
-  public Painter getDealWithDummyPainter(Deal deal, Direction direction, ActionListener playCardActionListener) {
+  public Painter getDealWithDummyPainter(Deal deal, Direction direction, ActionListener actionListener) {
     boolean dummyVisible = this.sbkingClient.getDeal().isDummyOpen();
     Direction dummy = this.sbkingClient.getDeal().getDummy();
-    return new DealWithDummyPainter(playCardActionListener, direction, deal, dummy, dummyVisible);
+    return new DealWithDummyPainter(actionListener, direction, deal, dummy, dummyVisible);
   }
 
 }

--- a/src/main/java/br/com/sbk/sbking/gui/painters/SpectatorPainter.java
+++ b/src/main/java/br/com/sbk/sbking/gui/painters/SpectatorPainter.java
@@ -5,9 +5,7 @@ import static br.com.sbk.sbking.logging.SBKingLogger.LOGGER;
 import java.awt.Container;
 import java.awt.event.ActionListener;
 
-import br.com.sbk.sbking.core.Board;
 import br.com.sbk.sbking.core.Deal;
-import br.com.sbk.sbking.core.rulesets.concrete.NoRuleset;
 import br.com.sbk.sbking.gui.elements.AllDirectionBoardElements;
 import br.com.sbk.sbking.gui.elements.ScoreSummaryElement;
 
@@ -19,11 +17,6 @@ public class SpectatorPainter implements Painter {
     public SpectatorPainter(ActionListener actionListener, Deal deal) {
         this.actionListener = actionListener;
         this.deal = deal;
-    }
-
-    public SpectatorPainter(ActionListener actionListener, Board board) {
-        this.actionListener = actionListener;
-        this.deal = new Deal(board, new NoRuleset(), null);
     }
 
     @Override

--- a/src/main/java/br/com/sbk/sbking/gui/painters/WaitingForChoosingGameModeOrStrainPainter.java
+++ b/src/main/java/br/com/sbk/sbking/gui/painters/WaitingForChoosingGameModeOrStrainPainter.java
@@ -47,7 +47,7 @@ public class WaitingForChoosingGameModeOrStrainPainter implements Painter {
         }
 
         new SpecificDirectionBoardElements(this.myDirection, this.sbKingClient.getDeal(), contentPane,
-                this.sbKingClient.getPlayCardActionListener());
+                this.sbKingClient.getActionListener());
 
         contentPane.validate();
         contentPane.repaint();

--- a/src/main/java/br/com/sbk/sbking/gui/painters/WaitingForChoosingPositiveOrNegativePainter.java
+++ b/src/main/java/br/com/sbk/sbking/gui/painters/WaitingForChoosingPositiveOrNegativePainter.java
@@ -45,7 +45,7 @@ public class WaitingForChoosingPositiveOrNegativePainter implements Painter {
         }
 
         new SpecificDirectionBoardElements(this.myDirection, this.sbKingClient.getDeal(), contentPane,
-                this.sbKingClient.getPlayCardActionListener());
+                this.sbKingClient.getActionListener());
 
         contentPane.validate();
         contentPane.repaint();

--- a/src/main/java/br/com/sbk/sbking/gui/screens/CagandoNoBequinhoScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/screens/CagandoNoBequinhoScreen.java
@@ -22,6 +22,9 @@ public class CagandoNoBequinhoScreen extends GameScreen {
         }
 
         while (true) {
+            if (!this.checkIfStillIsOnGameScreen()) {
+                return; // Exits when server says it is not on the game anymore.
+            }
             if (sbkingClient.isSpectator()) {
                 if (sbkingClient.getDealHasChanged() || ClientApplicationState.getGUIHasChanged()) {
                     if (!ClientApplicationState.getGUIHasChanged()) {
@@ -31,7 +34,7 @@ public class CagandoNoBequinhoScreen extends GameScreen {
                     Deal currentDeal = sbkingClient.getDeal();
                     if (currentDeal != null) {
                         Painter painter = this.painterFactory.getSpectatorPainter(currentDeal,
-                                sbkingClient.getPlayCardActionListener());
+                                sbkingClient.getActionListener());
                         sbkingClientJFrame.paintPainter(painter);
                     }
                 }
@@ -45,7 +48,7 @@ public class CagandoNoBequinhoScreen extends GameScreen {
 
                     LOGGER.info("Starting to paint Deal");
                     Painter painter = this.painterFactory.getDealPainter(currentDeal, sbkingClient.getDirection(),
-                            sbkingClient.getPlayCardActionListener());
+                            sbkingClient.getActionListener());
                     sbkingClientJFrame.paintPainter(painter);
                     LOGGER.info("Finished painting Deal");
                 }

--- a/src/main/java/br/com/sbk/sbking/gui/screens/GameScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/screens/GameScreen.java
@@ -23,4 +23,8 @@ public abstract class GameScreen implements SBKingScreen {
     }
   }
 
+  protected boolean checkIfStillIsOnGameScreen() {
+    return sbkingClient.getGameName() != null;
+  }
+
 }

--- a/src/main/java/br/com/sbk/sbking/gui/screens/KingScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/screens/KingScreen.java
@@ -23,6 +23,9 @@ public class KingScreen extends GameScreen {
 
         while (true) {
             sleepFor(300);
+            if (!this.checkIfStillIsOnGameScreen()) {
+                return; // Exits when server says it is not on the game anymore.
+            }
             if (sbkingClient.isSpectator()) {
                 if (sbkingClient.getDealHasChanged() || ClientApplicationState.getGUIHasChanged()) {
                     if (!ClientApplicationState.getGUIHasChanged()) {
@@ -32,7 +35,7 @@ public class KingScreen extends GameScreen {
                     Deal currentDeal = sbkingClient.getDeal();
                     if (currentDeal != null) {
                         Painter painter = this.painterFactory.getSpectatorPainter(currentDeal,
-                                sbkingClient.getPlayCardActionListener());
+                                sbkingClient.getActionListener());
                         sbkingClientJFrame.paintPainter(painter);
                     }
                 }
@@ -47,7 +50,7 @@ public class KingScreen extends GameScreen {
                     Deal currentDeal = sbkingClient.getDeal();
                     if (currentDeal != null) {
                         Painter painter = this.painterFactory.getDealPainter(currentDeal, sbkingClient.getDirection(),
-                                sbkingClient.getPlayCardActionListener());
+                                sbkingClient.getActionListener());
                         sbkingClientJFrame.paintPainter(painter);
                     }
                     LOGGER.info("Finished painting Deal");

--- a/src/main/java/br/com/sbk/sbking/gui/screens/LobbyScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/screens/LobbyScreen.java
@@ -12,14 +12,30 @@ public class LobbyScreen implements SBKingScreen {
 
   public LobbyScreen(SBKingClient sbkingClient) {
     this.sbkingClient = sbkingClient;
+    this.sbkingClient.sendGetTables();
   }
 
   @Override
   public void runAt(SBKingClientJFrame sbkingClientJFrame) {
 
     LOGGER.info("Entered Lobby Screen");
-    sbkingClientJFrame.paintPainter(new LobbyScreenPainter(this.sbkingClient));
-    LOGGER.info("isDirectionOrSpectatorSet. Leaving Lobby Screen");
+    while (this.sbkingClient.getTables() == null) {
+      sleepFor(100);
+      LOGGER.info("Waiting to get tables from server.");
+    }
+    sbkingClientJFrame
+        .paintPainter(new LobbyScreenPainter(this.sbkingClient.getTables(), this.sbkingClient.getActionListener()));
+    LOGGER.info("Waiting to receive gameName from server.");
+    while (this.sbkingClient.getGameName() == null) {
+      sleepFor(100);
+    }
   }
 
+  private void sleepFor(int miliseconds) {
+    try {
+      Thread.sleep(miliseconds);
+    } catch (InterruptedException e) {
+      LOGGER.debug(e);
+    }
+  }
 }

--- a/src/main/java/br/com/sbk/sbking/gui/screens/MinibridgeScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/screens/MinibridgeScreen.java
@@ -23,6 +23,9 @@ public class MinibridgeScreen extends GameScreen {
 
     while (true) {
       sleepFor(300);
+      if (!this.checkIfStillIsOnGameScreen()) {
+        return; // Exits when server says it is not on the game anymore.
+      }
       if (sbkingClient.isSpectator()) {
         if (sbkingClient.getDealHasChanged() || ClientApplicationState.getGUIHasChanged()) {
           if (!ClientApplicationState.getGUIHasChanged()) {
@@ -31,8 +34,7 @@ public class MinibridgeScreen extends GameScreen {
           }
           Deal currentDeal = sbkingClient.getDeal();
           if (currentDeal != null) {
-            Painter painter = this.painterFactory.getSpectatorPainter(currentDeal,
-                sbkingClient.getPlayCardActionListener());
+            Painter painter = this.painterFactory.getSpectatorPainter(currentDeal, sbkingClient.getActionListener());
             sbkingClientJFrame.paintPainter(painter);
           }
         }
@@ -45,7 +47,7 @@ public class MinibridgeScreen extends GameScreen {
           }
           LOGGER.info("Starting to paint Deal");
           Painter painter = this.painterFactory.getDealWithDummyPainter(sbkingClient.getDeal(),
-              sbkingClient.getDirection(), sbkingClient.getPlayCardActionListener());
+              sbkingClient.getDirection(), sbkingClient.getActionListener());
           sbkingClientJFrame.paintPainter(painter);
           LOGGER.info("Finished painting Deal");
         } else {

--- a/src/main/java/br/com/sbk/sbking/gui/screens/PositiveKingScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/screens/PositiveKingScreen.java
@@ -23,6 +23,9 @@ public class PositiveKingScreen extends GameScreen {
 
         while (true) {
             sleepFor(300);
+            if (!this.checkIfStillIsOnGameScreen()) {
+                return; // Exits when server says it is not on the game anymore.
+            }
             if (sbkingClient.isSpectator()) {
                 if (sbkingClient.getDealHasChanged() || ClientApplicationState.getGUIHasChanged()) {
                     if (!ClientApplicationState.getGUIHasChanged()) {
@@ -32,7 +35,7 @@ public class PositiveKingScreen extends GameScreen {
                     Deal currentDeal = sbkingClient.getDeal();
                     if (currentDeal != null) {
                         Painter painter = this.painterFactory.getSpectatorPainter(currentDeal,
-                                sbkingClient.getPlayCardActionListener());
+                                sbkingClient.getActionListener());
                         sbkingClientJFrame.paintPainter(painter);
                     }
                 }
@@ -45,7 +48,7 @@ public class PositiveKingScreen extends GameScreen {
                     }
                     LOGGER.info("Starting to paint Deal");
                     Painter painter = this.painterFactory.getDealPainter(sbkingClient.getDeal(),
-                            sbkingClient.getDirection(), sbkingClient.getPlayCardActionListener());
+                            sbkingClient.getDirection(), sbkingClient.getActionListener());
                     sbkingClientJFrame.paintPainter(painter);
                     LOGGER.info("Finished painting Deal");
                 } else {

--- a/src/main/java/br/com/sbk/sbking/gui/screens/WelcomeScreen.java
+++ b/src/main/java/br/com/sbk/sbking/gui/screens/WelcomeScreen.java
@@ -51,15 +51,15 @@ public class WelcomeScreen implements SBKingScreen {
 
   @Override
   public void runAt(SBKingClientJFrame sbkingClientJFrame) {
-    LOGGER.info("Starting to paint ConnectToServerScreen");
+    LOGGER.info("Starting to paint WelcomeScreen");
     sbkingClientJFrame.paintPainter(new ConnectToServerPainter(this));
-    LOGGER.info("Finished painting ConnectToServerScreen");
+    LOGGER.info("Finished painting WelcomeScreen");
 
     LOGGER.info("Waiting for connectedToServer to be true");
     while (!connectedToServer) {
       sleepFor(100);
     }
-    LOGGER.info("connectedToServer is true. Leaving ConnectToNetworkScreen");
+    LOGGER.info("connectedToServer is true. Leaving WelcomeScreen");
   }
 
   private void sleepFor(int miliseconds) {

--- a/src/main/java/br/com/sbk/sbking/networking/client/SBKingClient.java
+++ b/src/main/java/br/com/sbk/sbking/networking/client/SBKingClient.java
@@ -1,7 +1,10 @@
 package br.com.sbk.sbking.networking.client;
 
+import java.util.List;
+
 import br.com.sbk.sbking.core.Deal;
 import br.com.sbk.sbking.core.Direction;
+import br.com.sbk.sbking.dto.LobbyScreenTableDTO;
 import br.com.sbk.sbking.gui.listeners.ClientActionListener;
 import br.com.sbk.sbking.gui.models.KingGameScoreboard;
 import br.com.sbk.sbking.gui.models.PositiveOrNegative;
@@ -22,7 +25,7 @@ public class SBKingClient {
 
     private KingGameScoreboard currentGameScoreboard = new KingGameScoreboard();
 
-    private ClientActionListener playCardActionListener;
+    private ClientActionListener actionListener;
 
     private boolean spectator;
 
@@ -30,8 +33,10 @@ public class SBKingClient {
 
     private String gameName;
 
-    public void setPlayCardActionListener(ClientActionListener playCardActionListener) {
-        this.playCardActionListener = playCardActionListener;
+    private List<LobbyScreenTableDTO> tables;
+
+    public void setActionListener(ClientActionListener actionListener) {
+        this.actionListener = actionListener;
     }
 
     public void setKryonetSBKingClient(KryonetSBKingClient kryonetSBKingClient) {
@@ -157,8 +162,8 @@ public class SBKingClient {
         return this.rulesetValid != null;
     }
 
-    public ClientActionListener getPlayCardActionListener() {
-        return this.playCardActionListener;
+    public ClientActionListener getActionListener() {
+        return this.actionListener;
     }
 
     public boolean isSpectator() {
@@ -189,6 +194,10 @@ public class SBKingClient {
         this.kryonetSBKingClient.setAndSendNickname(nickname);
     }
 
+    public void sendGetTables() {
+        this.kryonetSBKingClient.sendGetTablesMessage();
+    }
+
     public void setPositiveOrNegative(String content) {
         String positive = "POSITIVE";
         String negative = "NEGATIVE";
@@ -211,5 +220,13 @@ public class SBKingClient {
 
     public String getGameName() {
         return gameName;
+    }
+
+    public void setTables(List<LobbyScreenTableDTO> tables) {
+        this.tables = tables;
+    }
+
+    public List<LobbyScreenTableDTO> getTables() {
+        return tables;
     }
 }

--- a/src/main/java/br/com/sbk/sbking/networking/client/SBKingClientFactory.java
+++ b/src/main/java/br/com/sbk/sbking/networking/client/SBKingClientFactory.java
@@ -26,8 +26,8 @@ public class SBKingClientFactory {
     SBKingClientMessageConsumer sbKingClientMessageConsumer = new SBKingClientMessageConsumer(sbKingClient,
         clientMessageQueue); // Consumer
     new Thread(sbKingClientMessageConsumer, "msg-consumer").start();
-    sbKingClient.setPlayCardActionListener(
-        new ClientActionListener(new KryonetSBKingClientActionListener(kryonetSBKingClient)));
+    sbKingClient
+        .setActionListener(new ClientActionListener(new KryonetSBKingClientActionListener(kryonetSBKingClient)));
     LOGGER.info("Trying to connect.");
     try {
       kryonetSBKingClient.connect(5000, hostname, port);

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetClientListenerFactory.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetClientListenerFactory.java
@@ -17,17 +17,6 @@ public class KryonetClientListenerFactory {
     return new Listener() {
       public void connected(Connection connection) {
         LOGGER.debug("Entered --connected-- lifecycle method.");
-        KryonetSBKingClient kryonetSBKingClient = null;
-
-        try {
-          kryonetSBKingClient = (KryonetSBKingClient) client;
-        } catch (Exception e) {
-          LOGGER.fatal("client should be a KryonetSBKingClient");
-          LOGGER.fatal(client);
-          return;
-        }
-
-        kryonetSBKingClient.sendGetTablesMessage();
       }
 
       public void received(Connection connection, Object object) {

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingClient.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingClient.java
@@ -2,6 +2,8 @@ package br.com.sbk.sbking.networking.kryonet;
 
 import static br.com.sbk.sbking.logging.SBKingLogger.LOGGER;
 
+import java.util.UUID;
+
 import com.esotericsoftware.kryonet.Client;
 
 import br.com.sbk.sbking.core.Card;
@@ -12,6 +14,8 @@ import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.ChooseNegati
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.ChoosePositiveMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.CreateTableMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.GetTablesMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.JoinTableMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.LeaveTableMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.MoveToSeatMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.PlayCardMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.SetNicknameMessage;
@@ -65,6 +69,14 @@ public class KryonetSBKingClient extends Client {
 
   public void sendGetTablesMessage() {
     this.sendMessage(new GetTablesMessage());
+  }
+
+  public void sendJoinTable(UUID tableId) {
+    this.sendMessage(new JoinTableMessage(tableId));
+  }
+
+  public void sendLeaveTable() {
+    this.sendMessage(new LeaveTableMessage());
   }
 
 }

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingClientActionListener.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingClientActionListener.java
@@ -1,5 +1,7 @@
 package br.com.sbk.sbking.networking.kryonet;
 
+import java.util.UUID;
+
 import br.com.sbk.sbking.core.Card;
 import br.com.sbk.sbking.core.Direction;
 
@@ -21,6 +23,14 @@ public class KryonetSBKingClientActionListener {
 
   public void undo() {
     client.sendUndo();
+  }
+
+  public void joinTable(UUID tableId) {
+    client.sendJoinTable(tableId);
+  }
+
+  public void leaveTable() {
+    client.sendLeaveTable();
   }
 
 }

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingServer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetSBKingServer.java
@@ -5,6 +5,7 @@ import static br.com.sbk.sbking.logging.SBKingLogger.LOGGER;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.StreamSupport;
 
 import com.esotericsoftware.kryonet.Server;
 
@@ -74,13 +75,12 @@ public class KryonetSBKingServer extends Server {
     }
   }
 
-  private void sendAll(SBKingMessage message) {
-    LOGGER.debug("Sending everyone " + message.getClass().toString());
-    this.sendToAllTCP(message); // This will need to change when there are multiple tables.
+  private void sendMany(SBKingMessage message, Iterable<UUID> receivers) {
+    StreamSupport.stream(receivers.spliterator(), false).forEach(clientId -> this.sendOneTo(message, clientId));
   }
 
-  public void sendFinishDealAll() {
-    this.sendAll(new FinishDealMessage());
+  public void sendFinishDealTo(Iterable<UUID> receivers) {
+    this.sendMany(new FinishDealMessage(), receivers);
   }
 
   public void sendDirectionTo(Direction direction, UUID playerIdentifier) {
@@ -95,36 +95,36 @@ public class KryonetSBKingServer extends Server {
     this.sendOneTo(new IsNotSpectatorMessage(), playerIdentifier);
   }
 
-  public void sendDealAll(Deal deal) {
-    this.sendAll(new DealMessage(deal));
+  public void sendDealTo(Deal deal, Iterable<UUID> receivers) {
+    this.sendMany(new DealMessage(deal), receivers);
   }
 
   public void sendDealTo(Deal deal, UUID playerIdentifier) {
     this.sendOneTo(new DealMessage(deal), playerIdentifier);
   }
 
-  public void sendGameModeOrStrainChooserAll(Direction direction) {
-    this.sendAll(new GameModeOrStrainChooserMessage(direction));
+  public void sendGameModeOrStrainChooserTo(Direction direction, Iterable<UUID> receivers) {
+    this.sendMany(new GameModeOrStrainChooserMessage(direction), receivers);
   }
 
-  public void sendPositiveOrNegativeChooserAll(Direction direction) {
-    this.sendAll(new PositiveOrNegativeChooserMessage(direction));
+  public void sendPositiveOrNegativeChooserTo(Direction direction, Iterable<UUID> receivers) {
+    this.sendMany(new PositiveOrNegativeChooserMessage(direction), receivers);
   }
 
-  public void sendPositiveOrNegativeAll(String positiveOrNegative) {
-    this.sendAll(new PositiveOrNegativeMessage(positiveOrNegative));
+  public void sendPositiveOrNegativeTo(String positiveOrNegative, Iterable<UUID> receivers) {
+    this.sendMany(new PositiveOrNegativeMessage(positiveOrNegative), receivers);
   }
 
-  public void sendInitializeDealAll() {
-    this.sendAll(new InitializeDealMessage());
+  public void sendInitializeDealTo(Iterable<UUID> receivers) {
+    this.sendMany(new InitializeDealMessage(), receivers);
   }
 
-  public void sendInvalidRulesetAll() {
-    this.sendAll(new InvalidRulesetMessage());
+  public void sendInvalidRulesetTo(Iterable<UUID> receivers) {
+    this.sendMany(new InvalidRulesetMessage(), receivers);
   }
 
-  public void sendValidRulesetAll() {
-    this.sendAll(new ValidRulesetMessage());
+  public void sendValidRulesetTo(Iterable<UUID> receivers) {
+    this.sendMany(new ValidRulesetMessage(), receivers);
   }
 
   public String getNicknameFromIdentifier(UUID identifier) {
@@ -143,14 +143,4 @@ public class KryonetSBKingServer extends Server {
     this.sendOneTo(new GetTablesResponseMessage(tablesDTO), playerIdentifier);
   }
 
-  // public void enterTable(){
-  // Table table = this.sbkingServer.getTable();
-  // if (table != null) {
-  // GameServer gameServer = table.getGameServer();
-  // String gameName =
-  // GameNameFromGameServerIdentifier.identify(gameServer.getClass());
-  // this.sendYourTableIsTo(gameName, identifier);
-  // this.sbkingServer.addSpectator(identifier, table.getId());
-  // }
-  // }
 }

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetServerListenerFactory.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetServerListenerFactory.java
@@ -43,6 +43,8 @@ public class KryonetServerListenerFactory {
 
         TextMessage response = new TextMessage("You just connected! Welcome to SBKing!");
         connection.sendTCP(response);
+
+        kryonetSBKingServer.sendYourTableIsTo(null, connectionWithPlayer.getIdentifier());
       }
 
       public void received(Connection connection, Object object) {

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetUtils.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/KryonetUtils.java
@@ -45,6 +45,8 @@ import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.ChooseNegati
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.ChoosePositiveMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.CreateTableMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.GetTablesMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.JoinTableMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.LeaveTableMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.MoveToSeatMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.PlayCardMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.SetNicknameMessage;
@@ -138,6 +140,8 @@ public class KryonetUtils {
     kryo.register(ChoosePositiveMessage.class);
     kryo.register(CreateTableMessage.class);
     kryo.register(GetTablesMessage.class);
+    kryo.register(JoinTableMessage.class);
+    kryo.register(LeaveTableMessage.class);
     kryo.register(MoveToSeatMessage.class);
     kryo.register(PlayCardMessage.class);
     kryo.register(SetNicknameMessage.class);

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/SBKingClientMessageConsumer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/SBKingClientMessageConsumer.java
@@ -79,13 +79,7 @@ public class SBKingClientMessageConsumer implements Runnable {
     } else if (message instanceof YourTableIsMessage) {
       this.sbkingClient.setGameName((String) content);
     } else if (message instanceof GetTablesResponseMessage) {
-      List<LobbyScreenTableDTO> tables = (List<LobbyScreenTableDTO>) content;
-      LOGGER.info("The tables are: \n\n\n\n");
-      for (LobbyScreenTableDTO table : tables) {
-        LOGGER.info("Id: " + table.getId());
-        LOGGER.info("Game Name: " + table.getGameName());
-        LOGGER.info("Number of specs: " + table.getNumberOfSpectators());
-      }
+      this.sbkingClient.setTables((List<LobbyScreenTableDTO>) content);
     } else {
       LOGGER.error("Could not understand message.");
       LOGGER.error(message);

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/SBKingServerMessageConsumer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/SBKingServerMessageConsumer.java
@@ -15,6 +15,8 @@ import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.ChooseNegati
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.ChoosePositiveMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.CreateTableMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.GetTablesMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.JoinTableMessage;
+import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.LeaveTableMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.MoveToSeatMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.PlayCardMessage;
 import br.com.sbk.sbking.networking.kryonet.messages.ClientToServer.SetNicknameMessage;
@@ -70,10 +72,16 @@ public class SBKingServerMessageConsumer implements Runnable {
       this.sbkingServer.createTable(gameServerClass);
     } else if (message instanceof GetTablesMessage) {
       this.sbkingServer.sendTablesTo(playerIdentifier);
+    } else if (message instanceof JoinTableMessage) {
+      JoinTableMessage joinTableMessage = (JoinTableMessage) message;
+      this.sbkingServer.joinTable(playerIdentifier, joinTableMessage.getContent());
+    } else if (message instanceof LeaveTableMessage) {
+      this.sbkingServer.leaveTable(playerIdentifier);
     } else {
       LOGGER.error("Could not understand message.");
       LOGGER.error(message);
     }
+
   }
 
 }

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/messages/ClientToServer/JoinTableMessage.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/messages/ClientToServer/JoinTableMessage.java
@@ -1,0 +1,26 @@
+package br.com.sbk.sbking.networking.kryonet.messages.ClientToServer;
+
+import java.util.UUID;
+
+import br.com.sbk.sbking.networking.kryonet.messages.SBKingMessage;
+
+public class JoinTableMessage implements SBKingMessage {
+
+  private UUID tableId;
+
+  /**
+   * @deprecated Kryo needs a no-arg constructor
+   */
+  private JoinTableMessage() {
+  }
+
+  public JoinTableMessage(UUID tableId) {
+    this.tableId = tableId;
+  }
+
+  @Override
+  public UUID getContent() {
+    return this.tableId;
+  }
+
+}

--- a/src/main/java/br/com/sbk/sbking/networking/kryonet/messages/ClientToServer/LeaveTableMessage.java
+++ b/src/main/java/br/com/sbk/sbking/networking/kryonet/messages/ClientToServer/LeaveTableMessage.java
@@ -1,0 +1,15 @@
+package br.com.sbk.sbking.networking.kryonet.messages.ClientToServer;
+
+import br.com.sbk.sbking.networking.kryonet.messages.SBKingMessage;
+
+public class LeaveTableMessage implements SBKingMessage {
+
+  public LeaveTableMessage() {
+  }
+
+  @Override
+  public String getContent() {
+    return null;
+  }
+
+}

--- a/src/main/java/br/com/sbk/sbking/networking/server/Table.java
+++ b/src/main/java/br/com/sbk/sbking/networking/server/Table.java
@@ -71,7 +71,6 @@ public class Table {
     Player currentSeatedPlayer = this.seatedPlayers.get(direction);
     if (currentSeatedPlayer != null) {
       this.removeFromSeatedPlayers(currentSeatedPlayer);
-      this.gameServer.getDeal().unsetPlayerOf(direction);
       this.spectatorPlayers.add(currentSeatedPlayer);
       this.getSBKingServer().sendIsSpectatorTo(currentSeatedPlayer.getIdentifier());
     }
@@ -100,7 +99,6 @@ public class Table {
       LOGGER.debug("Trying to move from " + from.getCompleteName() + " to " + to.getCompleteName() + ".");
 
       this.removeFromSeatedPlayers(player);
-      this.gameServer.getDeal().unsetPlayerOf(from);
 
       seatedPlayers.put(to, player);
       this.getSBKingServer().sendDirectionTo(to, player.getIdentifier());
@@ -143,6 +141,7 @@ public class Table {
     if (playerDirection != null) {
       LOGGER.debug("Removing player from " + playerDirection.getCompleteName());
       seatedPlayers.remove(playerDirection);
+      this.gameServer.getDeal().unsetPlayerOf(playerDirection);
     }
   }
 
@@ -184,7 +183,7 @@ public class Table {
   }
 
   public void sendDealAll() {
-    this.getSBKingServer().sendDealAll(this.gameServer.getDeal());
+    this.getSBKingServer().sendDealToTable(this.gameServer.getDeal(), this);
   }
 
   public void sendDealTo(Player player) {
@@ -207,6 +206,7 @@ public class Table {
     Player player = this.allPlayers.get(identifier);
     if (player != null) {
       this.removePlayer(player);
+      this.sendDealAll();
     }
   }
 

--- a/src/main/java/br/com/sbk/sbking/networking/server/gameServer/CagandoNoBequinhoGameServer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/server/gameServer/CagandoNoBequinhoGameServer.java
@@ -16,6 +16,7 @@ public class CagandoNoBequinhoGameServer extends GameServer {
     public void run() {
 
         while (!game.isFinished()) {
+            this.game.dealNewBoard();
 
             this.copyPlayersFromTableToGame();
 
@@ -57,7 +58,7 @@ public class CagandoNoBequinhoGameServer extends GameServer {
 
             this.game.finishDeal();
 
-            this.sbkingServer.sendFinishDealAll();
+            this.sbkingServer.sendFinishDealToTable(this.table);
             LOGGER.info("Deal finished!");
 
         }

--- a/src/main/java/br/com/sbk/sbking/networking/server/gameServer/GameServer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/server/gameServer/GameServer.java
@@ -82,19 +82,19 @@ public abstract class GameServer implements Runnable {
     }
 
     protected void sendDealAll() {
-        this.getSBKingServer().sendDealAll(this.game.getCurrentDeal());
+        this.getSBKingServer().sendDealToTable(this.game.getCurrentDeal(), this.table);
     }
 
     protected void sendInitializeDealAll() {
-        this.getSBKingServer().sendInitializeDealAll();
+        this.getSBKingServer().sendInitializeDealToTable(this.table);
     }
 
     protected void sendInvalidRulesetAll() {
-        this.getSBKingServer().sendInvalidRulesetAll();
+        this.getSBKingServer().sendInvalidRulesetToTable(this.table);
     }
 
     protected void sendValidRulesetAll() {
-        this.getSBKingServer().sendValidRulesetAll();
+        this.getSBKingServer().sendValidRulesetToTable(this.table);
     }
 
     public void undo(Direction direction) {

--- a/src/main/java/br/com/sbk/sbking/networking/server/gameServer/KingGameServer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/server/gameServer/KingGameServer.java
@@ -40,7 +40,7 @@ public class KingGameServer extends GameServer {
                 this.sendInitializeDealAll();
                 LOGGER.info("Sleeping for 300ms waiting for clients to initialize its deals.");
                 sleepFor(300);
-                this.getSBKingServer().sendDealAll(this.game.getCurrentDeal());
+                this.getSBKingServer().sendDealToTable(this.game.getCurrentDeal(), this.table);
                 sleepFor(300);
                 this.sendPositiveOrNegativeChooserAll();
 
@@ -150,7 +150,7 @@ public class KingGameServer extends GameServer {
 
             LOGGER.info("Sleeping for 300ms waiting for all clients to prepare themselves.");
             sleepFor(300);
-            this.sbkingServer.sendFinishDealAll();
+            this.sbkingServer.sendFinishDealToTable(this.table);
             LOGGER.info("Deal finished!");
             LOGGER.info("Sleeping for 300ms waiting for all clients to prepare themselves.");
             sleepFor(300);
@@ -188,15 +188,15 @@ public class KingGameServer extends GameServer {
     }
 
     private void sendGameModeOrStrainChooserAll() {
-        this.sbkingServer.sendGameModeOrStrainChooserAll(this.getCurrentGameModeOrStrainChooser());
+        this.sbkingServer.sendGameModeOrStrainChooserToTable(this.getCurrentGameModeOrStrainChooser(), this.table);
     }
 
     private void sendPositiveOrNegativeChooserAll() {
-        this.sbkingServer.sendPositiveOrNegativeChooserAll(this.getCurrentPositiveOrNegativeChooser());
+        this.sbkingServer.sendPositiveOrNegativeChooserToTable(this.getCurrentPositiveOrNegativeChooser(), this.table);
     }
 
     private void sendPositiveOrNegativeAll() {
-        this.sbkingServer.sendPositiveOrNegativeAll(this.currentPositiveOrNegative);
+        this.sbkingServer.sendPositiveOrNegativeToTable(this.currentPositiveOrNegative, this.table);
     }
 
 }

--- a/src/main/java/br/com/sbk/sbking/networking/server/gameServer/MinibridgeGameServer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/server/gameServer/MinibridgeGameServer.java
@@ -105,7 +105,7 @@ public class MinibridgeGameServer extends GameServer {
 
       this.game.finishDeal();
 
-      this.sbkingServer.sendFinishDealAll();
+      this.sbkingServer.sendFinishDealToTable(this.table);
       LOGGER.info("Deal finished!");
     }
 
@@ -153,7 +153,7 @@ public class MinibridgeGameServer extends GameServer {
   }
 
   private void sendGameModeOrStrainChooserAll() {
-    this.sbkingServer.sendGameModeOrStrainChooserAll(this.getCurrentGameModeOrStrainChooser());
+    this.sbkingServer.sendGameModeOrStrainChooserToTable(this.getCurrentGameModeOrStrainChooser(), this.table);
   }
 
 }

--- a/src/main/java/br/com/sbk/sbking/networking/server/gameServer/PositiveKingGameServer.java
+++ b/src/main/java/br/com/sbk/sbking/networking/server/gameServer/PositiveKingGameServer.java
@@ -119,7 +119,7 @@ public class PositiveKingGameServer extends GameServer {
 
             this.game.finishDeal();
 
-            this.sbkingServer.sendFinishDealAll();
+            this.sbkingServer.sendFinishDealToTable(this.table);
             LOGGER.info("Deal finished!");
 
         }
@@ -157,7 +157,7 @@ public class PositiveKingGameServer extends GameServer {
     }
 
     private void sendGameModeOrStrainChooserAll() {
-        this.sbkingServer.sendGameModeOrStrainChooserAll(this.getCurrentGameModeOrStrainChooser());
+        this.sbkingServer.sendGameModeOrStrainChooserToTable(this.getCurrentGameModeOrStrainChooser(), this.table);
     }
 
 }


### PR DESCRIPTION
Sorry for the LOOOONG PR.

Closes #90 
Closes #91 

This includes:
- Join table
- Leave table
- Table cards (cartões) at `LobbyScreen`
- Rename `playCardActionListener` -> `clientActionListener`
- Remove unused painter constructors that uses `Board`
- Implement client screen logic: should I paint LobbyScreen or GameScreen?
- Adequate network communication to use tables (sendAll -> sendToTable)