### PR TITLE
[build] split lo4gj into 2 different configurations

### DIFF
--- a/src/main/resources/log4j2-dev-debug.xml
+++ b/src/main/resources/log4j2-dev-debug.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+  <Properties>
+    <Property name="filename">target/errors.log</Property>
+  </Properties>
+  <Appenders>
+    <Console name="LogToConsole" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{ABSOLUTE}|%-5p|%-15t|%-20C{1}:%3L| %m%n" />
+    </Console>
+    <File name="allErrors" fileName="${filename}">
+      <PatternLayout pattern="%d{ABSOLUTE}|%-5p|%-15t|%-20C{1}:%3L| %m%n" />
+    </File>
+  </Appenders>
+  <Loggers>
+    <Root level="DEBUG">
+      <AppenderRef ref="LogToConsole" level="INFO" />
+      <AppenderRef ref="allErrors" level="WARN" />
+    </Root>
+  </Loggers>
+</Configuration>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,20 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="INFO">
-    <Properties>
-        <Property name="filename">target/errors.log</Property>
-    </Properties>
     <Appenders>
         <Console name="LogToConsole" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ABSOLUTE}|%-5p|%-15t|%-20C{1}:%3L| %m%n" />
         </Console>
-        <File name="allErrors" fileName="${filename}">
-            <PatternLayout pattern="%d{ABSOLUTE}|%-5p|%-15t|%-20C{1}:%3L| %m%n" />
-        </File>
     </Appenders>
     <Loggers>
         <Root level="DEBUG">
             <AppenderRef ref="LogToConsole" level="INFO" />
-            <AppenderRef ref="allErrors" level="WARN" />
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
This avoids clients to have a directory named "target" created on the place that they open sbking.